### PR TITLE
Restore custom map on event listing/search page

### DIFF
--- a/event_search.html
+++ b/event_search.html
@@ -154,17 +154,17 @@ a.area-link.event-link:hover {
 {% endblock %}
 
 {% block tail_js %}
-<script type="text/javascript" src="https://350dotorg.github.io/megamap/js/tabletop.js"></script>
 <script type="text/javascript">
       RAH = {};
-      RAH.sprite_url = "https://s3.amazonaws.com/static.local.350.org/images/map_markers/map-pin-single.png";
-      RAH.multiple_sprite_url = "https://s3.amazonaws.com/static.local.350.org/images/map_markers/map-pin-multiple.png";
+      RAH.sprite_url = "https://350-ak-map-assets.netlify.com/images/marker-single.png";
+      RAH.multiple_sprite_url = "https://350-ak-map-assets.netlify.com/images/marker-cluster.png";
       // Add locations for plotting on the map
       RAH.event_locations = [];
       RAH.map_center = {};
 </script>
 <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAyc65HgY18lHPM_vjvZS-jgkqpZPwaCDc&sensor=false"></script>
 <script type="text/javascript" src="https://s3.amazonaws.com/s3.350.org/js/map/markerclusterer.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
 $.urlParam = function(name){
@@ -293,7 +293,7 @@ window.mapEvents = [
 {% if not event.is_private %}{% if event.host_is_confirmed and event.status == "active" %}{% if event.is_approved or not campaign.require_staff_approval %}
 {
 "event_id": "{{ event.id }}", "created_at": "{{ event.created_at }}", "updated_at": "{{ event.updated_at }}", "address1": "{{ event.address1 }}", "address2": "{{ event.address2 }}", "city": "{{ event.city }}", "state": "{{ event.state }}", "region": "{{ event.region }}", "postal": "{{ event.postal }}", "zip": "{{ event.zip }}", "plus4": "{{ event.plus4 }}",
-"country": "{{ event.country }}", "longitude": {% if event.custom_fields.longitude350 %}{{ event.custom_fields.longitude350 }} {% else %}{{ event.longitude }}{% endif %}, "latitude": {% if event.custom_fields.latitude350 %}{{ event.custom_fields.latitude350 }} {% else %}{{ event.latitude }}{% endif %}, "campaign_id": "{{ event.campaign_id }}", "title": "{{ event.title }}", "creator_id": "{{ event.creator_id }}", "starts_at": "{{ event.starts_at|date:'c' }}", "ends_at": "{{ event.ends_at|date:'c' }}", "status": "{{ event.status }}", "host_is_confirmed": "{{ event.host_is_confirmed }}", "is_private": "{{ event.is_private }}", "is_approved": "{{ event.is_approved }}", 
+"country": "{{ event.country }}", "longitude": {% if event.custom_fields.geocoded_longitude %}{{ event.custom_fields.geocoded_longitude }} {% else %}{{ event.longitude }}{% endif %}, "latitude": {% if event.custom_fields.geocoded_latitude %}{{ event.custom_fields.geocoded_latitude }} {% else %}{{ event.latitude }}{% endif %}, "campaign_id": "{{ event.campaign_id }}", "title": "{{ event.title }}", "creator_id": "{{ event.creator_id }}", "starts_at": "{{ event.starts_at|date:'c' }}", "ends_at": "{{ event.ends_at|date:'c' }}", "status": "{{ event.status }}", "host_is_confirmed": "{{ event.host_is_confirmed }}", "is_private": "{{ event.is_private }}", "is_approved": "{{ event.is_approved }}", 
 "attendee_count": "{{ event.attendee_count }}", "max_attendees": "{{ event.max_attendees }}", "venue": "{{ event.venue }}", 
 "public_description": "{{ event.public_description|linebreaksbr|escapejs }}",
 "directions": "{{ event.directions|linebreaksbr|escapejs }}",
@@ -330,49 +330,6 @@ var $sel = function(selector) {
 };
 
 var featured_events = [], featured_events_ready = false, featured_events_highlighted = false;
-function getFeaturedEventsFromSpreadsheet(data) {
-  for( var i=0; i<data.length; ++i ) {
-    if( parseInt(data[i].eventid) ) {
-      featured_events.push(parseInt(data[i].eventid));
-    }
-  }
-  featured_events_ready = true;
-  var el = $("#event_search_results_event_list");
-  if( el && el.length ) {
-    highlightFeaturedEvents(el);
-  }
-};
-Tabletop.init({
-    	key: "0Agcr__L1I1PDdHdwUkpZcmxlLW85bTlrWHBLT3ZEcUE",
-        simpleSheet: true,
-    	callback: getFeaturedEventsFromSpreadsheet,
-    	debug: false,
-        proxy: "https://350dotorg.github.io/megamap-data"
-    });
-
-function highlightFeaturedEvents(el) {
-  if( featured_events_highlighted ) return;
-  var events = el.find("li[data-event_id]");
-  if( !events || !events.length ) {
-    html = el.html();
-    $sel('#event-search-results, .event-search-results').html(html);
-    return;
-  }
-  var parent = events.parent();
-  for( var i=events.length-1; i>=0; --i ) {
-    var event = events[i];
-    var arrayPosition = $.inArray($(event).data("event_id"), featured_events);
-    if( arrayPosition != -1 ) {
-      var insertBefore = parent.find("li:first");
-
-      $(event).css("background-color", "yellow").addClass("featuredEvent");
-      if( insertBefore.data("event_id") != $(event).data("event_id") ) {
-        $(event).insertBefore(insertBefore);
-      }
-    }
-  }
-  featured_events_highlighted = true;
-}
 
 function fitMapToEvents(el) {
   var events = el.find("li[data-event_id]");
@@ -406,6 +363,9 @@ actionkit.forms.onEventSearchResults = function(html) {
     $sel('#event-search-results, .event-search-results').html(html);
   }
 };
+$(window).load(function() {
+	initData([], []);
+});
 </script>
 
 {% endblock %}


### PR DESCRIPTION
* Now serving assets from a Netlify site instead of broken Github Pages + S3 backends
* Move to current custom field names for more-precisely-geolocated events
* Discard tabletop + google sheets infrastructure for indicating certain events should be "highlighted" above all others