### PR TITLE
Testing CVV removal by commenting out first to test preview mode

### DIFF
--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4231,7 +4231,7 @@ label.ak-survey-radio-choice {
 }
 
 .input-cc-expiration label,
-.input-cvv label,
+/* .input-cvv label, */
 #ak-fieldbox-exp_date label,
 #ak-fieldbox-card_code label {
   padding-right: 0;

--- a/donate.html
+++ b/donate.html
@@ -497,13 +497,13 @@
 			        </select>
 							<div class="clear"></div>
 						</div>
-				    <div id="ak-fieldbox-card_code" class="input-text input-cvv ak-input-type-user c5 ct5 margin-top-none">
+				    <!-- <div id="ak-fieldbox-card_code" class="input-text input-cvv ak-input-type-user c5 ct5 margin-top-none">
 			        <input type="hidden" name="required" value="card_code" id="ak-card_code-required">
 			        <label for="ak-card_code" title="The 3–4 digit security code on the back of your card.">{% filter ak_text:"field_card_code" %}CVV{% endfilter %}</label>
 			        <div id="ak-card_code-hosted" class="hosted-field"></div>
 			        <input id="ak-card_code" type="text" name="card_code" size="4">
 				    </div>
-				    <div class="clear"></div>
+				    <div class="clear"></div> -->
 					</div>
 					{% if templateset.custom_fields.pre_submit_text %}
 					<div class="pre-submit-text">
@@ -1453,9 +1453,9 @@ $(function() {
                 number: {
                     selector: '#ak-card_num-hosted'
                 },
-                cvv: {
-                    selector: '#ak-card_code-hosted'
-                },
+                // cvv: {
+                //     selector: '#ak-card_code-hosted'
+                // },
                 expirationDate: {
                     selector: '#ak-exp_date-hosted',
                     placeholder: 'MM / YYYY'
@@ -1507,7 +1507,7 @@ $(function() {
                 err.details.invalidFieldKeys.forEach(function(key) {
                     var map = {
                         'number': 'card_num',
-                        'cvv': 'card_code',
+                        // 'cvv': 'card_code', // Comment this out for now
                         'expirationDate': 'card_exp'
                     };
                     actionkit.errors[map[key] + ':invalid'] = "This field is invalid.";;


### PR DESCRIPTION
**What does this PR do?**

Currently comments out the code for CVV validation and request for the donation pages in 3 locations:
1. Javascript. There is a `map` that iterates and checks whether the CVV field is present.
2. HTML (Template Engine for Django) - Comments out the structural reference.
3. CSS - We no longer need to style it if it is not there.

**Testing?**
Live to the donation-sprint branch