### PR TITLE
Cleanup CVV code removal after successful testing

### DIFF
--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4231,7 +4231,6 @@ label.ak-survey-radio-choice {
 }
 
 .input-cc-expiration label,
-/* .input-cvv label, */
 #ak-fieldbox-exp_date label,
 #ak-fieldbox-card_code label {
   padding-right: 0;

--- a/donate.html
+++ b/donate.html
@@ -497,13 +497,6 @@
 			        </select>
 							<div class="clear"></div>
 						</div>
-				    <!-- <div id="ak-fieldbox-card_code" class="input-text input-cvv ak-input-type-user c5 ct5 margin-top-none">
-			        <input type="hidden" name="required" value="card_code" id="ak-card_code-required">
-			        <label for="ak-card_code" title="The 3–4 digit security code on the back of your card.">{% filter ak_text:"field_card_code" %}CVV{% endfilter %}</label>
-			        <div id="ak-card_code-hosted" class="hosted-field"></div>
-			        <input id="ak-card_code" type="text" name="card_code" size="4">
-				    </div>
-				    <div class="clear"></div> -->
 					</div>
 					{% if templateset.custom_fields.pre_submit_text %}
 					<div class="pre-submit-text">
@@ -1453,9 +1446,6 @@ $(function() {
                 number: {
                     selector: '#ak-card_num-hosted'
                 },
-                // cvv: {
-                //     selector: '#ak-card_code-hosted'
-                // },
                 expirationDate: {
                     selector: '#ak-exp_date-hosted',
                     placeholder: 'MM / YYYY'
@@ -1507,7 +1497,6 @@ $(function() {
                 err.details.invalidFieldKeys.forEach(function(key) {
                     var map = {
                         'number': 'card_num',
-                        // 'cvv': 'card_code', // Comment this out for now
                         'expirationDate': 'card_exp'
                     };
                     actionkit.errors[map[key] + ':invalid'] = "This field is invalid.";;


### PR DESCRIPTION
**What does this PR do?**

Removes the code for CVV validation and request for the donation pages in 3 locations:

Javascript. There is a map that iterates and checks whether the CVV field is present.
HTML Template for ActionKits Django Set up - Comments out the structural reference.
CSS - We no longer need to style it if it is not there.

**Testing?**
Live to the donation-sprint [branch](https://act.350.org/donate/build_2019sprint/)

**Old UI**
![Screenshot 2019-11-26 at 14 40 25](https://user-images.githubusercontent.com/22073299/69627027-e6975580-105a-11ea-995e-8cbe9fd93944.png)

**Updated UI**
![Screenshot 2019-11-26 at 14 39 14](https://user-images.githubusercontent.com/22073299/69627008-dbdcc080-105a-11ea-9627-3a0d178745d8.png)

Fixes this issue [#39](https://gitlab.com/350/web-tools/actionkit/issues/39)