### PR TITLE
fix: change state of checkbox only once when either side is clicked

### DIFF
--- a/assets/ak-v3.js
+++ b/assets/ak-v3.js
@@ -754,11 +754,11 @@ jQuery(document).ready(function($){
   var checkbox = document.querySelector('.input-checkbox input');
 
   once.addEventListener('click', function () {
-    checkbox.checked = false;
+    if (checkbox.checked) checkbox.checked = false;
   })
 
   monthly.addEventListener('click', function () {
-    checkbox.checked = true;
+    if (!checkbox.checked) checkbox.checked = true;
   })
 
 });


### PR DESCRIPTION
Realised you'd see a transition still if you click on either side of the toggle more than once. Fixed it so now if the checkbox is unchecked, it would become checked only once, and vice versa. Should hopefully remove that transition glitch.