### PR TITLE
fix: remove event.preventDefault from donation type toggle functions

### DIFF
--- a/assets/ak-v3.js
+++ b/assets/ak-v3.js
@@ -755,12 +755,10 @@ jQuery(document).ready(function($){
 
   once.addEventListener('click', function (e) {
     if (checkbox.checked) checkbox.checked = false;
-    else e.preventDefault();
   })
 
   monthly.addEventListener('click', function (e) {
     if (!checkbox.checked) checkbox.checked = true;
-    else e.preventDefault();
   })
 
 });


### PR DESCRIPTION
Realised event.preventDefault wasn't needed to fix the transition glitch as there was no glitch after all!