### PR TITLE
fix: only redirect attend pages, attempt #2

### DIFF
--- a/wrapper.html
+++ b/wrapper.html
@@ -54,7 +54,7 @@
 	<!-- End Google Tag Manager -->
 
 
-	{% if event.custom_fields.url and '/attend/' in request.path %}
+	{% if event.custom_fields.url and concat('/attend\/\',event.id,'(\/attend/)?/') in request.path %}
 	<meta http-equiv="refresh" content="0;url={{ event.custom_fields.url }}" />
 	<style>
 		#redirect-overlay {


### PR DESCRIPTION
Using regex to handle cases where url is pre-filled and when it isn't.