### PR TITLE
Feature signup currency

### DIFF
--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -1,4 +1,3 @@
-{% extends "./wrapper.html" %}
 {% comment %}
 Custom template for same-page post-AJAX submit share ask.
 {% endcomment %}
@@ -171,6 +170,7 @@ Custom template for same-page post-AJAX submit share ask.
 
 <script>
 jQuery(document).ready(function($){
+	console.log("we actually got here");
 	/* only run the AJAX submission if we're sure this is an AK-hosted page */
 	if ( $('html').hasClass('ak-hosted') ){
 		let initDonateAmounts = [];

--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -1,7 +1,9 @@
+{% extends "./wrapper.html" %}
 {% comment %}
 Custom template for same-page post-AJAX submit share ask.
 {% endcomment %}
 
+{{page}}
 {% load actionkit_tags %}
 
 {% if page.custom_fields.after_action_next_step != "page-redirect" %}
@@ -171,6 +173,13 @@ Custom template for same-page post-AJAX submit share ask.
 jQuery(document).ready(function($){
 	/* only run the AJAX submission if we're sure this is an AK-hosted page */
 	if ( $('html').hasClass('ak-hosted') ){
+		let initDonateAmounts = [];
+		let userCountry;
+		let exchangeRateData = {};
+		let exchangeApiUrl = 'https://api.exchangeratesapi.io/latest?base=USD';
+		$.get(exchangeApiUrl, function (data, status) {
+			exchangeRateData = data.rates;
+		});
 		// set up variables
 		var afteractionProgressMeter = $("#afteraction-progress-meter");
 
@@ -184,6 +193,60 @@ jQuery(document).ready(function($){
 		var afteractionDonateSlideInner = $('#afteraction-donate-inner');
 		var afteractionDonateAskContent = $('#afteraction-donate-ask-source').html();
 		var afteractionDonateContent = $('#afteraction-donate-source').html();
+
+		const euroCountries = ['Austria', 'Belgium', 'Cyprus', 'Estonia', 'Finland', 'France', 'Germany', 'Greece', 'Ireland', 'Italy', 'Latvia', 'Lithuania', 'Luxembourg', 'Malta', 'Netherlands', 'Portugal', 'Slovakia', 'Slovenia', 'Spain'];
+
+		function updateDonateCurrency(userLocation){
+			if (euroCountries.includes(userLocation)) {
+				userLocation = 'Europe';
+			}
+			var currencyData = {
+				/* uses API exchange data, with hardcoded (out of date) exchange rate as fallback */
+				'Canada': {
+					currencySymbol: '$',
+					currency: 'CAD',
+					exchangeRate: exchangeRateData['CAD'] || 1.45
+				},
+				'Australia': {
+					currencySymbol: '$',
+					currency: 'AUD',
+					exchangeRate:  exchangeRateData['AUD']  || 1.68
+				},
+				'New Zealand': {
+					currencySymbol: '$',
+					currency: 'NZD',
+					exchangeRate:  exchangeRateData['NZD'] || 1.72
+				},
+				'United Kingdom': {
+					currencySymbol: '£',
+					currency: 'GBP',
+					exchangeRate: exchangeRateData['GBP'] || 0.85
+				},
+				'Europe': {
+					currencySymbol: '€',
+					currency: 'EUR',
+					exchangeRate: exchangeRateData['EUR'] || 0.92
+				},
+				'Brazil': {
+					currencySymbol: 'R$',
+					currency: 'BRL',
+					exchangeRate: exchangeRateData['BRL'] || 5.07
+				}
+			};
+			if (currencyData[userLocation]) {
+				$('#afteraction-donate-inner .afteraction-donate-amount-container a').each(function(i){
+					// replace amount and add currency param in donate button urls
+					var $this = $(this);
+					var originalAmt = initDonateAmounts[i];
+					var convertedAmt = Math.ceil(originalAmt * currencyData[userLocation].exchangeRate);
+					var url = $(this).attr('href');
+                    var newUrl = url.split('amount')[0] + 'amount=' + convertedAmt + '&source=' + url.split('&source=')[1] + '&currency=' + currencyData[userLocation].currency;
+                    $this.attr('href', newUrl);
+					// change button label
+                    $this.html(currencyData[userLocation].currencySymbol + convertedAmt);
+				});
+			}
+		}
 
 		function afteractionShowShareAsk(){
 			if ( afteractionShareSlideInner.html() == '' ){
@@ -219,6 +282,11 @@ jQuery(document).ready(function($){
 					.empty()
 					.append( afteractionDonateAskContent )
 					.animate({opacity:1}, 300);
+					// save initial donate amounts to be converted for each currency
+					$('#afteraction-donate-inner .afteraction-donate-amount-container a').each(function(){
+						initDonateAmounts.push(parseInt($(this).html().substring(1)));
+					});
+					updateDonateCurrency(userCountry);
 					$(document).trigger('domUpdated');
 					$('html, body').animate({
 						scrollTop: afteractionDonateSlide.offset().top
@@ -271,6 +339,8 @@ jQuery(document).ready(function($){
 						if (typeof fbq === "function") {
 							fbq('track', 'CompleteRegistration');
 						}
+						// save country for currency feature (needed for country prefill issue - FA)
+						userCountry = $('#country').val();
 						// show the share ask
 						afteractionShowShareAsk();
 						// if user opts to share, show share dialog

--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -170,7 +170,6 @@ Custom template for same-page post-AJAX submit share ask.
 
 <script>
 jQuery(document).ready(function($){
-	console.log("we actually got here");
 	/* only run the AJAX submission if we're sure this is an AK-hosted page */
 	if ( $('html').hasClass('ak-hosted') ){
 		let initDonateAmounts = [];

--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -2,7 +2,6 @@
 Custom template for same-page post-AJAX submit share ask.
 {% endcomment %}
 
-{{page}}
 {% load actionkit_tags %}
 
 {% if page.custom_fields.after_action_next_step != "page-redirect" %}
@@ -175,23 +174,23 @@ jQuery(document).ready(function($){
 		let initDonateAmounts = [];
 		let userCountry;
 		let exchangeRateData = {};
-		let exchangeApiUrl = 'https://api.exchangeratesapi.io/latest?base=USD';
+		const exchangeApiUrl = 'https://api.exchangeratesapi.io/latest?base=USD';
 		$.get(exchangeApiUrl, function (data, status) {
 			exchangeRateData = data.rates;
 		});
-		// set up variables
-		var afteractionProgressMeter = $("#afteraction-progress-meter");
 
-		var afteraction = $("#afteraction");
-		var afteractionShareSlide = $('#afteraction-share');
-		var afteractionShareSlideInner = $('#afteraction-share-inner');
-		var afteractionShareAskContent = $('#afteraction-share-ask-source').html();
-		var afteractionShareContent = $('#afteraction-share-source').html();
+		const afteractionProgressMeter = $("#afteraction-progress-meter");
 
-		var afteractionDonateSlide = $('#afteraction-donate');
-		var afteractionDonateSlideInner = $('#afteraction-donate-inner');
-		var afteractionDonateAskContent = $('#afteraction-donate-ask-source').html();
-		var afteractionDonateContent = $('#afteraction-donate-source').html();
+		const afteraction = $("#afteraction");
+		const afteractionShareSlide = $('#afteraction-share');
+		const afteractionShareSlideInner = $('#afteraction-share-inner');
+		const afteractionShareAskContent = $('#afteraction-share-ask-source').html();
+		const afteractionShareContent = $('#afteraction-share-source').html();
+
+		const afteractionDonateSlide = $('#afteraction-donate');
+		const afteractionDonateSlideInner = $('#afteraction-donate-inner');
+		const afteractionDonateAskContent = $('#afteraction-donate-ask-source').html();
+		const afteractionDonateContent = $('#afteraction-donate-source').html();
 
 		const euroCountries = ['Austria', 'Belgium', 'Cyprus', 'Estonia', 'Finland', 'France', 'Germany', 'Greece', 'Ireland', 'Italy', 'Latvia', 'Lithuania', 'Luxembourg', 'Malta', 'Netherlands', 'Portugal', 'Slovakia', 'Slovenia', 'Spain'];
 

--- a/donate.html
+++ b/donate.html
@@ -585,7 +585,7 @@
 				<p>350.org Limited is a registered Australian charity but donations are NOT tax-deductible in Australia. ABN: 46 138 155 192. Some donations for joint work with our partner organisation Climate Action Network Australia (CANA) can be made tax deductible. For information about that, please contact <a href="mailto:donations@350.org.au">donations@350.org.au</a>.</p>
 				{% else %}
 					{% filter ak_text:"donate_footer_text_block" %}
-<p><strong class="text-small-caps">Donate by Check:</strong> Make your check payable to <em>350.org</em> and mail it to <em>350.org, 20 Jay St, Suite 732, Brooklyn, NY 11201, USA</em>.</p>
+<p><strong class="text-small-caps">Donate by Check:</strong> Due to COVID-19 precautionary measures we are currently neither checking mail nor processing checks. If you wish to donate to 350, please kindly donate online or email <a href="mailto:donations@350.org">donations@350.org</a> for wire transfer information.</p>
 <p><strong class="text-small-caps">Other Ways To Give:</strong> <a href="https://350.org/other-ways-to-give/">Click here</a> to see additional options, including transferring stock.</p>
 <p><strong class="text-small-caps">Contact Us:</strong> Questions? Problems? Please contact us at <a href="mailto:donations@350.org?subject=Question%20about%20donation%20to%20350.org">donations@350.org</a>.</p>
 <p><strong class="text-small-caps">Update Your Account:</strong> To update your account with a new credit card, new expiration date, or new amount please visit <a href="https://350.org/update">350.org/update</a></p>

--- a/donate.html
+++ b/donate.html
@@ -585,7 +585,7 @@
 				<p>350.org Limited is a registered Australian charity but donations are NOT tax-deductible in Australia. ABN: 46 138 155 192. Some donations for joint work with our partner organisation Climate Action Network Australia (CANA) can be made tax deductible. For information about that, please contact <a href="mailto:donations@350.org.au">donations@350.org.au</a>.</p>
 				{% else %}
 					{% filter ak_text:"donate_footer_text_block" %}
-<p><strong class="text-small-caps">Donate by Check:</strong> Due to COVID-19 precautionary measures we are currently neither checking mail nor processing checks. If you wish to donate to 350, please kindly donate online or email <a href="mailto:donations@350.org">donations@350.org</a> for wire transfer information.</p>
+<p><strong class="text-small-caps">Donate by Check:</strong> Make your check payable to <em>350.org</em> and mail it to <em>350.org, 20 Jay St, Suite 732, Brooklyn, NY 11201, USA</em>.</p>
 <p><strong class="text-small-caps">Other Ways To Give:</strong> <a href="https://350.org/other-ways-to-give/">Click here</a> to see additional options, including transferring stock.</p>
 <p><strong class="text-small-caps">Contact Us:</strong> Questions? Problems? Please contact us at <a href="mailto:donations@350.org?subject=Question%20about%20donation%20to%20350.org">donations@350.org</a>.</p>
 <p><strong class="text-small-caps">Update Your Account:</strong> To update your account with a new credit card, new expiration date, or new amount please visit <a href="https://350.org/update">350.org/update</a></p>
@@ -744,6 +744,12 @@
     $(function() {
         $('input[id^=id_currency_], select[name="currency"], select[name="payment_account"]').on('change', redraw_currency_symbol);
         redraw_currency_symbol();
+
+        // preselect a currency with a url parameter
+			  var arg_currency = '{{ args.currency|default:"false" }}';
+        if (arg_currency && typeof actionkit.utils.currencySymbols[arg_currency] !== 'undefined') {
+          $('#id_currency_' + arg_currency).prop('selected', true);
+        }
     });
 
 

--- a/user_update.html
+++ b/user_update.html
@@ -23,7 +23,7 @@
 
 		<form name="accountupdate" method="POST" class="ak-form user-update">
 			<div id="form" class="user-update">
-				{% for field in form.visible_fields %}
+				{{ form.as_p }}
 				<input type="submit" class="submit" value="Update My Info" />
 			</div>
 		</form>

--- a/user_update.html
+++ b/user_update.html
@@ -1,5 +1,6 @@
 {% extends "./wrapper.html" %}
 {% load actionkit_tags %}
+{% load actionkit_tags switchcase %}
 
 {% block content %}
 <style>
@@ -23,7 +24,36 @@
 
 		<form name="accountupdate" method="POST" class="ak-form user-update">
 			<div id="form" class="user-update">
-				{{ form.as_p }}
+				{% for field in form.visible_fields %}
+				<div class="ak-labels-before" style="margin-bottom: 0.8em;">
+					<label for="{{ field.id_for_label }}">
+						{{ field.label }}
+					</label>
+
+					{% switch field.name %}
+					{% case 'country' %}
+					<select name="{{ input_name_prefix }}country" id="id_{{ input_name_prefix }}country"
+						{% if onchange %}onchange="{{ onchange }}" onblur="{{ onchange }}" {% endif %}>
+						<option selected="{{ field.value }}">{{ field.value }}</option>
+						{% for std_name,name in templateset.lang.country_names_us_first %}
+						<option value="{{ std_name|escapeall }}">{{ name|escapeall }}</option>
+						{% endfor %}
+					</select>
+					{% case 'state' %}
+					<script>
+						$(function () { //Make sure the current State value is selected
+							let selectedState = "{{ field.value }}";
+							$('#id_state > option[value=' + selectedState + ']').prop('selected', true);
+						})
+					</script>
+					{% include "./state_select.html" %}
+
+					{% else %}
+					{{ field }}
+					{% endswitch %}
+					{{ field.errors }}
+				</div>
+				{% endfor %}
 				<input type="submit" class="submit" value="Update My Info" />
 			</div>
 		</form>

--- a/user_update.html
+++ b/user_update.html
@@ -23,7 +23,7 @@
 
 		<form name="accountupdate" method="POST" class="ak-form user-update">
 			<div id="form" class="user-update">
-				{{ form.as_p }}
+				{% for field in form.visible_fields %}
 				<input type="submit" class="submit" value="Update My Info" />
 			</div>
 		</form>

--- a/user_update.html
+++ b/user_update.html
@@ -3,31 +3,35 @@
 
 {% block content %}
 <style>
-input, select, textarea{max-width: initial;}
+	input,
+	select,
+	textarea {
+		max-width: initial;
+	}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-skinny padding-normal bg-white">
 	<div class="section-inner">
 		<h2>{% block title %}Update Your Info{% endblock %}</h2>
-		<h3 class="section-header meta margin-bottom-large">{{ user.name }}</h3>		
+		<h3 class="section-header meta margin-bottom-large">{{ user.name }}</h3>
 		<div id="content" class="user-update">
 			{% if updated %}
-				<p>Thanks! Your information has been updated. <a href="/logout">Click here to log out.</a></p><br>
+			<p>Thanks! Your information has been updated. <a href="/logout">Click here to log out.</a></p><br>
 			{% endif %}
-<!--			<p class="lead">Update your information:</p>-->
+			<!--			<p class="lead">Update your information:</p>-->
 		</div>
-		
+
 		<form name="accountupdate" method="POST" class="ak-form user-update">
-			<div id="form" class="user-update">			
-				{{ form.as_p }}			
+			<div id="form" class="user-update">
+				{{ form.as_p }}
 				<input type="submit" class="submit" value="Update My Info" />
 			</div>
 		</form>
 	</div>
 </section>
 <script type="text/javascript">
-$(document).ready(function(){
-actionkit.forms.installOverlayLabelHandler();
-});
+	$(document).ready(function () {
+		actionkit.forms.installOverlayLabelHandler();
+	});
 </script>
 {% endblock content %}


### PR DESCRIPTION
Feature for the donate ask slide on scrolling signup pages. Updated to show the users currency and converted donate button amounts, based on the country they select in the signup form.

**afteraction-share.html**
- we make an api request to https://api.exchangeratesapi.io (if this fails, we default to hardcoded exchange rates that aren't up to date)
- we covert the donate amount and change the currency for users in Canada, Australia, New Zealand, United Kingdom and Europe. Otherwise we default to USD
- we pass in a currency URL parameter to the donate page (used to preselect currency)

**donate.html**
- if we have the currency parameter in the URL, we use it to preselect a currency on the donate page