### PR TITLE
pass currency to alternate donate url custom field if used

### DIFF
--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -233,17 +233,25 @@ jQuery(document).ready(function($){
 				}
 			};
 			if (currencyData[userLocation]) {
-				$('#afteraction-donate-inner .afteraction-donate-amount-container a').each(function(i){
-					// replace amount and add currency param in donate button urls
-					var $this = $(this);
-					var originalAmt = initDonateAmounts[i];
-					var convertedAmt = Math.ceil(originalAmt * currencyData[userLocation].exchangeRate);
-					var url = $(this).attr('href');
-                    var newUrl = url.split('amount')[0] + 'amount=' + convertedAmt + '&source=' + url.split('&source=')[1] + '&currency=' + currencyData[userLocation].currency;
-                    $this.attr('href', newUrl);
-					// change button label
-                    $this.html(currencyData[userLocation].currencySymbol + convertedAmt);
-				});
+				if ($('#afteraction-donate-inner .afteraction-donate-cta-container a').length) {
+					// update alternate donate url
+					let altDonateUrl = $('#afteraction-donate-inner .afteraction-donate-cta-container a').attr('href');
+					altDonateUrl.indexOf('?') > -1 ?  altDonateUrl += '&currency=' : altDonateUrl += '?currency=';
+					altDonateUrl += currencyData[userLocation].currency;
+					$('#afteraction-donate-inner .afteraction-donate-cta-container a').attr('href', altDonateUrl);
+				} else {
+					// update default donate buttons url
+					$('#afteraction-donate-inner .afteraction-donate-amount-container a').each(function(i){
+						var $this = $(this);
+						var originalAmt = initDonateAmounts[i];
+						var convertedAmt = Math.ceil(originalAmt * currencyData[userLocation].exchangeRate);
+						var url = $(this).attr('href');
+						var newUrl = url.split('amount')[0] + 'amount=' + convertedAmt + '&source=' + url.split('&source=')[1] + '&currency=' + currencyData[userLocation].currency;
+						$this.attr('href', newUrl);
+						// change button label
+						$this.html(currencyData[userLocation].currencySymbol + convertedAmt);
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
Updated action-share.html so that we're passing the currency parameter to the alternate after action donate url if that custom field is being used. Otherwise, pass currency and amount into the default after action donate buttons.

I've tested on this page:
https://act.350.org/sign/currency-demo/

Here are the default donate buttons, with the currency being passed through (as seen the mouseover tooltip in the bottom left of the screenshot)
![Screenshot 2020-08-05 at 16 27 01](https://user-images.githubusercontent.com/7903912/89432155-adaa9700-d738-11ea-9443-ee37525d6b2c.png)

The change in this PR adds the currency to the alternate donate URL defined in this custom field
![Screenshot 2020-08-05 at 16 27 41](https://user-images.githubusercontent.com/7903912/89432210-bf8c3a00-d738-11ea-92a1-19b7ff9cc7f7.png)

Here's the currency being passed through in the alternate donate button on my test page:
![Screenshot 2020-08-05 at 16 25 23](https://user-images.githubusercontent.com/7903912/89432370-f1050580-d738-11ea-8c3e-cd5893295240.png)
