### PR TITLE
[FA] September Sprint (donation-sprint)

### DIFF
--- a/assets/ak-v3.js
+++ b/assets/ak-v3.js
@@ -787,7 +787,7 @@ if (toggle_option_one && toggle_option_two) {
 
   function toggleHidden(nodes) {
     for (var node of nodes) {
-      node.classList.toggle('hidden')
+      node.classList.toggle('hidden');
     }
   }
 }

--- a/donate.html
+++ b/donate.html
@@ -111,6 +111,12 @@ iframe[width="1"][height="1"] {
   width: 50% !important;
   margin: 0 !important;
 }
+
+/* style for when the payment type above amounts custom field is set to Y */
+.paymenttype-above {
+  margin-top: -0.8em;
+  margin-bottom: 1.4em;
+}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
@@ -367,7 +373,7 @@ iframe[width="1"][height="1"] {
           	setTimeout(update_total, 0);
           %]
       	</script>
-
+        
 {% if not has_products %}
   {% if allow_monthly %}
     {% if page.custom_fields.donation_once_recurring_or_both|lower == "recurring" %}
@@ -1963,5 +1969,14 @@ iframe[width="1"][height="1"] {
     </script>
 {% endif %}
 {% endwith %}
+
+{% if page.custom_fields.donate_payment_frequency_above_amounts == 'Y' %}
+<script>
+  $(function() {
+    $('#ak-recurring-type').insertBefore('#ak-amount-list');
+    $('#ak-recurring-type').addClass('paymenttype-above');
+  });
+</script>
+{% endif %}
 
 {% endblock %}

--- a/donate.html
+++ b/donate.html
@@ -1803,6 +1803,28 @@ iframe[width="1"][height="1"] {
     });
 		{% endif %}
 
+
+    // check for currency param and set default
+    var getUrlParameter = function (sParam) {
+        var sPageURL = window.location.search.substring(1),
+            sURLVariables = sPageURL.split('&'),
+            sParameterName,
+            i;
+
+        for (i = 0; i < sURLVariables.length; i++) {
+            sParameterName = sURLVariables[i].split('=');
+
+            if (sParameterName[0] === sParam) {
+                return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+            }
+        }
+    };
+    $(function() {
+      if (getUrlParameter('currency')) {
+        $('#id_currency_'+getUrlParameter('currency')).attr('selected', true)
+        $('#ak-currency-switcher').trigger('change')
+      }
+		});
 //-->
 </script>
 

--- a/donate.html
+++ b/donate.html
@@ -98,6 +98,10 @@ iframe[width="1"][height="1"] {
     display: none;
 }
 
+/* fix cut off on some browsers on hosted fields */
+.hosted-field {
+  height: 55px;
+}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -1672,7 +1672,7 @@
       const titleCtn = $(title);
       titleCtn.click(function (e) {
           const clicked = $(e.target);
-          const parentHasClass = clicked.parents(`.${CONSTANTS.ACTIVE_PAYMENTS_CLASS}`).length > 0;
+          const parentHasClass = clicked.parents('.' + CONSTANTS.ACTIVE_PAYMENTS_CLASS).length > 0;
           if(parentHasClass) return;
             else {
             const closestDiv = clicked.closest('.payments-title');

--- a/donate.html
+++ b/donate.html
@@ -68,6 +68,7 @@
   border-color: #0f81e8;;
 }
 
+/* IE Fixes */
 .title-section-60, .title-section {
   display: -webkit-box;
   display: -webkit-flex;
@@ -75,6 +76,20 @@
   display: flex;
   flex-direction: column
 }
+
+/* IE fixes for footer */
+iframe[width="1"][height="1"] {
+  width: 0;
+  height: 0;
+  display: block;
+}
+
+#site-footer {
+  top: 0;
+  position: relative;
+  margin-top: 25px;
+}
+
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -102,6 +102,20 @@ iframe[width="1"][height="1"] {
 .hosted-field {
   height: 55px;
 }
+
+/* inline fields for expiry and cvv */
+
+.inline_fields {
+  display: flex;
+}
+.inline_fields>div:first-of-type {
+  border-top: 1px solid rgba(21, 36, 43, 0.3) !important;
+  width: 50% !important;
+}
+.inline_fields>div:last-of-type {
+  width: 50% !important;
+  margin: 0 !important;
+}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
@@ -652,47 +666,54 @@ iframe[width="1"][height="1"] {
                 <input id="id_email" class="" type="text" name="email">
               </div>
             <!--Credit Card-->
-            {% comment %} Show the Credit Card Number Field only when the custom field for donation_only_paypal is {% endcomment %}
+            {% comment %} Show the Credit Card Fields only when the custom field for donation_only_paypal is {% endcomment %}
             {% if not page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower != 'y'  %}
-            <div id="ak-fieldbox-card_num" class="input-text ak-input-type-user cc-fields">
-              <label for="ak-card_num">{% filter ak_text:"field_card_num" %}Credit Card #{% endfilter %}</label>
-              <input type="hidden" name="required" value="card_num" id="ak-card_num-required">
-              <div id="ak-card_num-hosted" class="hosted-field"></div>
-              <input id="ak-card_num" type="text" name="card_num">
-            </div>
-            {% endif %}
-
-            {% comment %} Show the Credit Card Expiration Field Field only when the custom field for donation_only_paypal is {% endcomment %}
-            <!--Error & Expiration Date-->
-            {% if not page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower != 'y'  %}
-              <div id="ak-fieldbox-exp_date" class="input-select input-cc-expiration ak-input-type-user cc-fields ak-err-below">
-                <input type="hidden" name="required" value="exp_date_month" id="ak-exp_date_month-required">
-                <label for="ak-exp_date_month">{% filter ak_text:"field_exp_date" %}Expiration Date{% endfilter %}</label>
-                <div id="ak-exp_date-hosted" class="hosted-field"></div>
-                <select id="ak-exp_date_month" class="input-cc-expiration-month c4 ct4 cm4 no-margin" type="text" name="exp_date_month">
-                  <option value="">MM</option>
-                  <option value="01">01</option>
-                  <option value="02">02</option>
-                  <option value="03">03</option>
-                  <option value="04">04</option>
-                  <option value="05">05</option>
-                  <option value="06">06</option>
-                  <option value="07">07</option>
-                  <option value="08">08</option>
-                  <option value="09">09</option>
-                  <option value="10">10</option>
-                  <option value="11">11</option>
-                  <option value="12">12</option>
-                </select>
-                <input type="hidden" name="required" value="exp_date_year" id="ak-exp_date_year-required">
-                <select id="ak-exp_date_year" type="text" class="input-cc-expiration-year c6 ct6 cm6 no-margin cc-fields" name="exp_date_year">
-                  <option value="">YYYY</option>
-                  {% for year in exp_years %}
-                  <option value="{{ year.two }}">{{ year.four }}</option>
-                  {% endfor %}
-                </select>
-                <div class="clear"></div>
+            <fieldset class="input-group cc-fields">
+              <div id="ak-fieldbox-card_num" class="input-text ak-input-type-user cc-fields">
+                <label for="ak-card_num">{% filter ak_text:"field_card_num" %}Credit Card #{% endfilter %}</label>
+                <input type="hidden" name="required" value="card_num" id="ak-card_num-required">
+                <div id="ak-card_num-hosted" class="hosted-field"></div>
+                <input id="ak-card_num" type="text" name="card_num">
               </div>
+              <div class="inline_fields">
+                <div id="ak-fieldbox-exp_date" class="input-select input-cc-expiration ak-input-type-user cc-fields ak-err-below">
+                  <input type="hidden" name="required" value="exp_date_month" id="ak-exp_date_month-required">
+                  <label for="ak-exp_date_month">{% filter ak_text:"field_exp_date" %}Expiration Date{% endfilter %}</label>
+                  <div id="ak-exp_date-hosted" class="hosted-field"></div>
+                  <select id="ak-exp_date_month" class="input-cc-expiration-month c4 ct4 cm4 no-margin" type="text" name="exp_date_month">
+                    <option value="">MM</option>
+                    <option value="01">01</option>
+                    <option value="02">02</option>
+                    <option value="03">03</option>
+                    <option value="04">04</option>
+                    <option value="05">05</option>
+                    <option value="06">06</option>
+                    <option value="07">07</option>
+                    <option value="08">08</option>
+                    <option value="09">09</option>
+                    <option value="10">10</option>
+                    <option value="11">11</option>
+                    <option value="12">12</option>
+                  </select>
+                  <input type="hidden" name="required" value="exp_date_year" id="ak-exp_date_year-required">
+                  <select id="ak-exp_date_year" type="text" class="input-cc-expiration-year c6 ct6 cm6 no-margin cc-fields" name="exp_date_year">
+                    <option value="">YYYY</option>
+                    {% for year in exp_years %}
+                    <option value="{{ year.two }}">{{ year.four }}</option>
+                    {% endfor %}
+                  </select>
+                  <div class="clear"></div>
+                </div>
+
+                <div id="ak-fieldbox-card_code" class="input-text input-cvv ak-input-type-user cc-fields c5 ct5 margin-top-none">
+                  <input type="hidden" name="required" value="card_code" id="ak-card_code-required">
+                  <label for="ak-card_code" title="The 3–4 digit security code on the back of your card.">{% filter ak_text:"field_card_code" %}CVV{% endfilter %}</label>
+                  <div id="ak-card_code-hosted" class="hosted-field"></div>
+                  <input id="ak-card_code" type="text" name="card_code" size="4">
+                  <div class="clear"></div>
+                </div>
+              </div>
+            </fieldset>              
             {% endif %}
 
 
@@ -1362,6 +1383,13 @@ iframe[width="1"][height="1"] {
         step_has_errors = true;
       }
 
+      if (!valid_credit_card_code($('#ak-card_code').val())) {
+        if (!actionkit.errors) actionkit.errors = {}
+        actionkit.errors['card_code:invalid'] = actionkit.forms.errorMessage('card_code:invalid');
+        actionkit.forms.onValidationErrors(actionkit.errors);
+        step_has_errors = true;
+      }
+
       console.log(step_has_errors, "Step Has Errors end of step 3?")
       return step_has_errors;
     }
@@ -1631,11 +1659,11 @@ iframe[width="1"][height="1"] {
 
         /* clear out CC info if entered */
         $('#ak-card_num').val('');
-        // $('#ak-card_code').val('');
+        $('#ak-card_code').val('');
 
         /* disable CC requirements */
         $('#ak-card_num-required').remove();
-        // $('#ak-card_code-required').remove();
+        $('#ak-card_code-required').remove();
         $('#ak-exp_date_month-required').remove();
         $('#ak-exp_date_year-required').remove();
 
@@ -1832,6 +1860,9 @@ iframe[width="1"][height="1"] {
                     number: {
                         selector: '#ak-card_num-hosted'
                     },
+                    cvv: {
+                        selector: '#ak-card_code-hosted'
+                    },
                     expirationDate: {
                         selector: '#ak-exp_date-hosted',
                         placeholder: 'MM / YYYY'
@@ -1857,10 +1888,10 @@ iframe[width="1"][height="1"] {
                 },
                 submit: form.querySelector(".ak-submit-button")
             },
-            toRemove = ["#ak-card_num", "#ak-exp_date_month",
+            toRemove = ["#ak-card_num", "#ak-card_code", "#ak-exp_date_month",
                         "#ak-exp_date_year", "#ak-card_num-required",
                          "#ak-exp_date_month-required",
-                        "#ak-exp_date_year-required"];
+                        "#ak-exp_date_year-required", "#ak-card_code-required"];
         toRemove.forEach(function(el) {
             $(el).remove();
         });
@@ -1880,6 +1911,7 @@ iframe[width="1"][height="1"] {
                     err.details.invalidFieldKeys.forEach(function(key) {
                         var map = {
                             'number': 'card_num',
+                            'cvv': 'card_code',
                             'expirationDate': 'card_exp'
                         };
                         actionkit.errors[map[key] + ':invalid'] = "This field is invalid.";;

--- a/donate.html
+++ b/donate.html
@@ -557,6 +557,11 @@
           <!-- <h5 class="margin-bottom-normal">{% filter ak_text:"donate_payment_information" %}Payment Information{% endfilter %}</h5> -->
           <div class="payments-container">
             <div class="payments-titles">
+              {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}
+                BUTTON APPEARANCE
+              {% else %}
+                Normal appearance
+              {% endif %}
               {% if not page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower != 'y'  %}
 
               <div class="payments-title payments-title-active card-title">

--- a/donate.html
+++ b/donate.html
@@ -117,6 +117,10 @@ iframe[width="1"][height="1"] {
   margin-top: -0.8em;
   margin-bottom: 1.4em;
 }
+/* make sure the select fills the page width on mobile */
+#ak-currency-switcher {
+  max-width: initial;
+}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -912,7 +912,7 @@
 		}
 
     // Sherezz and Kimani Did this. Blame them
-    actionkit.utils.ensureVisible = () => {console.log("Hi. ensurevisible is now an anonymous function.")};
+    actionkit.utils.ensureVisible = function () { console.log("Hi. ensurevisible is now an anonymous function.") };
 
     function redraw_currency_symbol() {
         var id = $('input[id^=id_currency_]:checked, option[id^=id_currency_]:selected').attr('id');
@@ -1650,8 +1650,8 @@
     const ccFields = $(".cc-fields");
     const paypalFields = $("paypal-fields");
 
-    const removeActivePaymentsClass = () => {
-      $.each(paymentsTitles, (index, title)=>{
+    const removeActivePaymentsClass = function () {
+      $.each(paymentsTitles, function (index, title) {
           const titleCtn = $(title);
           titleCtn.removeClass(CONSTANTS.ACTIVE_PAYMENTS_CLASS);
           paypalFieldSelectedStepThree = false;
@@ -1660,17 +1660,17 @@
     };
 
     // Use this to hide fields as appropriately
-    const toggleShowFields = (fields, show) => {
-      $.each(fields, (index, field)=>{
+    const toggleShowFields = function (fields, show) {
+      $.each(fields, function (index, field) {
         const fieldCtn = $(field);
         fieldCtn.css({'display': show ? 'block': 'none'});
       });
     };
 
 
-    $.each(paymentsTitles, (index, title)=>{
+    $.each(paymentsTitles, function (index, title) {
       const titleCtn = $(title);
-      titleCtn.click(e=>{
+      titleCtn.click(function (e) {
           const clicked = $(e.target);
           const parentHasClass = clicked.parents(`.${CONSTANTS.ACTIVE_PAYMENTS_CLASS}`).length > 0;
           if(parentHasClass) return;

--- a/donate.html
+++ b/donate.html
@@ -842,7 +842,7 @@
                 total += parseFloat(other);
         }
 
-        var new_total = total == 0 ? "" : "" + total.toFixed(0);
+        var new_total = total == 0 ? "" : "" + total.toFixed(2);
         if (new_total != $('#total').html() ) {
             $('.ak-donation-total-amount').html(new_total);
         }

--- a/donate.html
+++ b/donate.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <style>
-              .payments-titles {
+.payments-titles {
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -44,6 +44,25 @@
 
 .button:focus {
   outline: none;
+}
+
+.payment-title-button {
+  border: 2px solid #798890;
+  border-radius: 6px;
+  margin-right: 12px;
+  margin: 0 6px;
+  padding: 3px 0;
+}
+
+.payment-title-button:first-of-type {
+  margin-left: 0;
+}
+.payment-title-button:last-of-type {
+  margin-right: 0;
+}
+
+.payment-title-button.payments-title-active {
+  border-color: #0f81e8;;
 }
 
 </style>
@@ -557,20 +576,16 @@
           <!-- <h5 class="margin-bottom-normal">{% filter ak_text:"donate_payment_information" %}Payment Information{% endfilter %}</h5> -->
           <div class="payments-container">
             <div class="payments-titles">
-              {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}
-                BUTTON APPEARANCE
-              {% else %}
-                Normal appearance
-              {% endif %}
+              
               {% if not page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower != 'y'  %}
 
-              <div class="payments-title payments-title-active card-title">
+              <div class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} payments-title-active card-title ">
                 <svg width="150" height="40" class="payments-title-active">
                   <image href=https://dkaroyc5da26m.cloudfront.net/images/cards.svg width="150" height="40"/>
                 </svg>
               </div>
 
-              <div class="payments-title paypal-title">
+              <div class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} paypal-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %}">
                 <svg width="75" height="40">
                   <image href=https://dkaroyc5da26m.cloudfront.net/images/paypal-logo.svg width="75" height="40"/>
                 </svg>

--- a/donate.html
+++ b/donate.html
@@ -585,7 +585,7 @@
                 </svg>
               </div>
 
-              <div class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} paypal-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %}">
+              <div class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} paypal-title">
                 <svg width="75" height="40">
                   <image href=https://dkaroyc5da26m.cloudfront.net/images/paypal-logo.svg width="75" height="40"/>
                 </svg>

--- a/donate.html
+++ b/donate.html
@@ -68,6 +68,13 @@
   border-color: #0f81e8;;
 }
 
+.title-section-60, .title-section {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  flex-direction: column
+}
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -90,6 +90,10 @@ iframe[width="1"][height="1"] {
   margin-top: 25px;
 }
 
+#site-footer nav {
+  margin: 0;
+}
+
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -98,11 +98,6 @@ iframe[width="1"][height="1"] {
     display: none;
 }
 
-/* fix cut off on some browsers on hosted fields */
-.hosted-field {
-  height: 55px;
-}
-
 /* inline fields for expiry and cvv */
 
 .inline_fields {
@@ -1815,10 +1810,10 @@ iframe[width="1"][height="1"] {
 {% if pp.use_vzero %}
 <style type="text/css">
 .hosted-field {
-  height: 50px;
+  height: 67px;
   padding: 0px 7px;
   padding-top: 2em;
-  margin-bottom:0.7em;
+  padding-bottom: 0.7em;
 }
 .hosted-field.braintree-hosted-fields-invalid {
   border-color: {{ templateset.custom_fields.color_error }};

--- a/donate.html
+++ b/donate.html
@@ -842,7 +842,7 @@
                 total += parseFloat(other);
         }
 
-        var new_total = total == 0 ? "" : "" + total.toFixed(2);
+        var new_total = total == 0 ? "" : "" + (total % 1 != 0 ? total.toFixed(2) : total.toFixed(0));
         if (new_total != $('#total').html() ) {
             $('.ak-donation-total-amount').html(new_total);
         }

--- a/donate.html
+++ b/donate.html
@@ -1861,7 +1861,7 @@
         };
         actionkit.donations.initClient('{{ pp.client_token }}', options);
         // read by 3-step validation
-        console.log(err, "Error is here")
+        // console.log(err, "Error is here")
         actionkit.donations.skip_cc_validation = true;
         actionkit.donations.vzero = true;
       $(".hosted-field.braintree-hosted-fields-invalid").prev().css("background-color", "#fff0d4");

--- a/donate.html
+++ b/donate.html
@@ -848,6 +848,15 @@ iframe[width="1"][height="1"] {
     // TODO: Commented out code needs to go.
     let paypalFieldOptionSelectedStepThree = false;
 
+    // Prevent keypress interaction
+    // Using key code also for functionality in IE
+    $(document).keydown(function(e){
+      const which = e.which;
+      if(which === 13){
+        e.preventDefault();
+      }
+    });
+
     function clear_radio_buttons() {
         $('input.ak-amount-radio-button').prop('checked', false);
     }

--- a/donate.html
+++ b/donate.html
@@ -1390,10 +1390,17 @@ iframe[width="1"][height="1"] {
     }
 
     function step_2_validation() {
-			console.log('validating step 2');
+      console.log('validating step 2');
       var step_has_errors = false;
 
-	     return step_has_errors;
+      if (document.getElementById("country").value === "United States" && document.getElementById("id_state").value === "") {
+        if (!actionkit.errors) actionkit.errors = {};
+        actionkit.errors['state:missing'] = actionkit.forms.errorMessage('state:missing');
+        actionkit.forms.onValidationErrors(actionkit.errors);
+        step_has_errors = true;
+      }
+
+      return step_has_errors;
     }
 
     function step_1_validation() {

--- a/donate.html
+++ b/donate.html
@@ -53,6 +53,9 @@
   margin: 0 6px;
   padding: 3px 0;
 }
+.payment-title-button:hover {
+  border-color: #0f81e8;
+}
 
 .payment-title-button:first-of-type {
   margin-left: 0;

--- a/donate.html
+++ b/donate.html
@@ -94,6 +94,10 @@ iframe[width="1"][height="1"] {
   margin: 0;
 }
 
+.ak-multi-currency select::-ms-expand {
+    display: none;
+}
+
 </style>
 
 <section id="action-lead" class="section donate-lead action-lead title-section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/donate.html
+++ b/donate.html
@@ -902,7 +902,7 @@ iframe[width="1"][height="1"] {
                 total += parseFloat(other);
         }
 
-        var new_total = total == 0 ? "" : "" + (total % 1 != 0 ? total.toFixed(2) : total.toFixed(0));
+        var new_total = total === 0 ? "" : "" + (total % 1 != 0 ? total.toFixed(2) : total.toFixed(0));
         if (new_total != $('#total').html() ) {
             $('.ak-donation-total-amount').html(new_total);
         }

--- a/thanks.html
+++ b/thanks.html
@@ -6,7 +6,7 @@
 	.upsell_wrap {
 		display: flex;
 		justify-content: center;
-		max-width: 600px;
+		max-width: 680px;
  	 	margin: 0 auto;
 	}
 	#suggestions {
@@ -37,6 +37,15 @@
 		margin-bottom: 0;
 		border-radius: 1.4em 0 0 1.4em;
 		padding-left: 32px;
+		min-width: 130px;
+	}
+	.upsell_other_amt input.CAD,
+	.upsell_other_amt input.NZD {
+		padding-left: 65px;
+	}
+	.upsell_other_amt input.BRL,
+	.upsell_other_amt input.AUD {
+		padding-left: 48px;
 	}
 	.upsell_other_amt button {
 		width: 40%;
@@ -54,17 +63,18 @@
 		</form>
 		<div id="thanks-message" class="bg-dkgray-trans text-large3 c10 ct10 cm10 box box-huge margin-bottom-large">
 		{% include_tmpl form.thank_you_text %}
-
-		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
+		
+		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' and not action.orderrecurring %}
 			<script>
 				$(function() {
-					var currency = 'CAD';
+					var currency = 'USD';
 					var total = '10';
 					var maxDonation = 500;
 					var currencySymbols = {
 						"AUD": "$",
 						"BRL": "R$",
-						"CAD": "$",
+						"CAD": "CA$",
+						"NZD": "NZ$",
 						"EUR": "€",
 						"GBP": "£",
 						"USD": "$",
@@ -115,6 +125,7 @@
 					});
 
 					$('#other_symbol').html(currencySymbols[currency])
+					$('#other_amt').addClass(currency)
 					 
 					// used to test
 					// $('#test_no').val(total)

--- a/thanks.html
+++ b/thanks.html
@@ -12,16 +12,79 @@
 		{% include_tmpl form.thank_you_text %}
 
 		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
-		{{ action.order.amt }} total in local currency <br>
-		{{ action.order.currency }} currency used, like "USD" <br>
-		{{ action.order.total_converted }} rough USD equivalent of the donation <br>
+			<script>
+				$(function() {
+					var currency = 'USD';
+					var total = '10';
+					
+					{% if action.order.currency %}
+					currency = '{{action.order.currency}}';
+					{% endif %}
+					{% if action.order.total %}
+					total = '{{action.order.total}}';
+					{% endif %}
+					
+					var getCurrency = function(amount) {
+						return parseInt(amount).toLocaleString('en-US', { style: 'currency', currency: currency, minimumFractionDigits: 0, maximumFractionDigits: 0 });
+					}
+					
+					var makeButton = function(amount) {
+						$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'/mo</button>')	
+					}
+					
+					var url = 'https://act.350.org/donate/fa-test_recurring/?source=build-donate-ty&utm_source=build-donate-ty'
+					
+					var setupButtons = function() {
+						if (total) {
+							var lowerCalc = (total / 5) * 4
 
-		{% with amt="10" %}  
+							if (parseInt(lowerCalc) != parseInt(total) && parseInt(lowerCalc) != 0 && parseInt(lowerCalc) <= 500) {
+								makeButton(lowerCalc)
+							} else if(parseInt(total - 1) != parseInt(total) && parseInt(total - 1) != 0 && parseInt(total - 1) <= 500) {
+								makeButton(total - 1)
+							} else if (parseInt(total) > 500) {
+								makeButton((500 / 5) * 4)
+							}
+							if (total < 500) {
+								makeButton(total)	
+							} else {
+								makeButton(500)
+							}
+						}
+					}
+					
+					$('body').on('click', '.upsell_btn', function(e){
+						window.location.href = url + '&amount='+$(this).data('amt')
+					});
+					
+					$('body').on('click', '#other_amt_btn', function(e){
+						window.location.href = url + '&amount='+$('#other_amt').val()
+					});
+					 
+				    $('#test_no').val(total)
+					 
+					$('#test_no').on('input', function(e){
+						total = parseFloat($(this).val())
+						$('#suggestions').empty()
+					    setupButtons();
+					});
+					 
+					 setupButtons();
+				});
+			</script>
 
-		Suggestions: <br>
-			{{ (amt / 3)|floatformat }}
-			{{ ((amt / 3) * 2)|floatformat }}
-			{{ amt }}
+			<div class="test_wrap" style="margin-bottom:35px;">
+				<label>Test donation amount</label>
+				<input type="number" id="test_no">
+			</div>
+			
+			<h3>Can you donate monthly?</h3>
+			<div id="suggestions"></div>
+			<div class="other_amt">
+				<label>Other Amount</label>
+				<input type="text" id="other_amt">
+				<button id="other_amt_btn" class="button">Give Monthly</button>
+			</div>
 			{% endif %}
 		</div>
 		<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">

--- a/thanks.html
+++ b/thanks.html
@@ -10,6 +10,12 @@
 		</form>
 		<div id="thanks-message" class="bg-dkgray-trans text-large3 c10 ct10 cm10 box box-huge margin-bottom-large">
 		{% include_tmpl form.thank_you_text %}
+
+		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
+		{{ action.order.amt }} total in local currency <br>
+		{{ action.order.currency }} currency used, like "USD" <br>
+		{{ action.order.total_converted }} rough USD equivalent of the donation <br>
+		{% endif %}
 		</div>
 		<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">
 			<input type="hidden" name="utf8" value="&#x2714;" />
@@ -126,9 +132,7 @@
 {% endifequal %}
 
 </form>
-{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
-SHOW UPSELL
-{% endif %}
+
 		</div>
 	</div>
 		{% if page.custom_fields.thanks_show_map %}

--- a/thanks.html
+++ b/thanks.html
@@ -16,6 +16,7 @@
 				$(function() {
 					var currency = 'USD';
 					var total = '10';
+					var maxDonation = 500;
 					
 					{% if action.order.currency %}
 					currency = '{{action.order.currency}}';
@@ -32,23 +33,23 @@
 						$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'/mo</button>')	
 					}
 					
-					var url = 'https://act.350.org/donate/fa-test_recurring/?source=build-donate-ty&utm_source=build-donate-ty'
+					var url = 'https://act.350.org/donate/fa-test_recurring/?source=build-donate-ty&utm_source=build-donate-ty&currency='+currency
 					
 					var setupButtons = function() {
 						if (total) {
 							var lowerCalc = (total / 5) * 4
 
-							if (parseInt(lowerCalc) != parseInt(total) && parseInt(lowerCalc) != 0 && parseInt(lowerCalc) <= 500) {
+							if (parseInt(lowerCalc) != parseInt(total) && parseInt(lowerCalc) != 0 && parseInt(lowerCalc) <= maxDonation) {
 								makeButton(lowerCalc)
-							} else if(parseInt(total - 1) != parseInt(total) && parseInt(total - 1) != 0 && parseInt(total - 1) <= 500) {
+							} else if(parseInt(total - 1) != parseInt(total) && parseInt(total - 1) != 0 && parseInt(total - 1) <= maxDonation) {
 								makeButton(total - 1)
-							} else if (parseInt(total) > 500) {
-								makeButton((500 / 5) * 4)
+							} else if (parseInt(total) > maxDonation) {
+								makeButton((maxDonation / 5) * 4)
 							}
-							if (total < 500) {
+							if (total < maxDonation) {
 								makeButton(total)	
 							} else {
-								makeButton(500)
+								makeButton(maxDonation)
 							}
 						}
 					}

--- a/thanks.html
+++ b/thanks.html
@@ -15,6 +15,13 @@
 		{{ action.order.amt }} total in local currency <br>
 		{{ action.order.currency }} currency used, like "USD" <br>
 		{{ action.order.total_converted }} rough USD equivalent of the donation <br>
+
+		{% remember 10 as amt %}
+
+		Suggestions: <br>
+		{% (amt / 3)|floatformat %}
+		{% ((amt / 3) * 2)|floatformat %}
+		{% amt %}
 		{% endif %}
 		</div>
 		<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">

--- a/thanks.html
+++ b/thanks.html
@@ -2,6 +2,35 @@
 {% load actionkit_tags %}
 {% block content %}
 {% autoescape off %}
+<style>
+	.upsell_wrap {
+		display: flex;
+		justify-content: center;
+		max-width: 600px;
+ 	 	margin: 0 auto;
+	}
+	#suggestions {
+		display: flex;
+	}
+	#suggestions button {
+		margin: 10px;
+		padding: 0.6em 1.2em;
+		font-size: 1.4rem;
+	}
+	.upsell_other_amt {
+		display: flex;
+	}
+	.upsell_other_amt input {
+		width: 60%;
+		font-size: 1.4rem;
+		margin-bottom: 0;
+		border-radius: 1.4em 0 0 1.4em;
+	}
+	.upsell_other_amt button {
+		width: 40%;
+  	border-radius: 0 1.4em 1.4em 0;
+	}
+</style>
 <section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 	<div class="section-inner">
 		<form class="ak-form dummy" name="act" method="POST" action="/act/" accept-charset="utf-8">
@@ -62,30 +91,33 @@
 						window.location.href = url + '&amount='+$('#other_amt').val()
 					});
 					 
-				    $('#test_no').val(total)
+					// used to test
+					// $('#test_no').val(total)
 					 
-					$('#test_no').on('input', function(e){
-						total = parseFloat($(this).val())
-						$('#suggestions').empty()
-					    setupButtons();
-					});
+					// $('#test_no').on('input', function(e){
+					// 	total = parseFloat($(this).val())
+					// 	$('#suggestions').empty()
+					//     setupButtons();
+					// });
 					 
 					 setupButtons();
 				});
 			</script>
 
-			<div class="test_wrap" style="margin-bottom:35px;">
+			<!-- used to test -->
+			<!-- <div class="test_wrap" style="margin-bottom:35px;">
 				<label>Test donation amount</label>
 				<input type="number" id="test_no">
 			</div>
-			
-			<h3>Can you donate monthly?</h3>
-			<div id="suggestions"></div>
-			<div class="other_amt">
-				<label>Other Amount</label>
-				<input type="text" id="other_amt">
-				<button id="other_amt_btn" class="button">Give Monthly</button>
-			</div>
+			 -->
+			 <div class="upsell_wrap">
+					<div id="suggestions"></div>
+					<div class="upsell_other_amt">
+						<input type="number" id="other_amt">
+						<button id="other_amt_btn" class="button">Give Monthly</button>
+					</div>
+			 </div>
+
 			{% endif %}
 		</div>
 		<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">

--- a/thanks.html
+++ b/thanks.html
@@ -20,12 +20,23 @@
 	.upsell_other_amt {
 		display: flex;
 		margin: 10px;
+		position: relative;
+	}
+	.upsell_other_amt label {
+		position: absolute;
+		color: #989898;
+		top: 50%;
+		transform: translateY(-50%);
+		left: 15px;
+		font-size: 1.4rem;
+		pointer-events: none;
 	}
 	.upsell_other_amt input {
 		width: 60%;
 		font-size: 1.4rem;
 		margin-bottom: 0;
 		border-radius: 1.4em 0 0 1.4em;
+		padding-left: 32px;
 	}
 	.upsell_other_amt button {
 		width: 40%;

--- a/thanks.html
+++ b/thanks.html
@@ -16,13 +16,13 @@
 		{{ action.order.currency }} currency used, like "USD" <br>
 		{{ action.order.total_converted }} rough USD equivalent of the donation <br>
 
-		{% remember 10 as amt %}
+		{% with amt="10" %}  
 
 		Suggestions: <br>
-		{% (amt / 3)|floatformat %}
-		{% ((amt / 3) * 2)|floatformat %}
-		{% amt %}
-		{% endif %}
+			{{ (amt / 3)|floatformat }}
+			{{ ((amt / 3) * 2)|floatformat }}
+			{{ amt }}
+			{% endif %}
 		</div>
 		<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">
 			<input type="hidden" name="utf8" value="&#x2714;" />

--- a/thanks.html
+++ b/thanks.html
@@ -19,6 +19,7 @@
 	}
 	.upsell_other_amt {
 		display: flex;
+		margin: 10px;
 	}
 	.upsell_other_amt input {
 		width: 60%;
@@ -28,7 +29,10 @@
 	}
 	.upsell_other_amt button {
 		width: 40%;
-  	border-radius: 0 1.4em 1.4em 0;
+		border-radius: 0 1.4em 1.4em 0;
+		min-width: 155px;
+		padding-left: 10px;
+		padding-right: 10px;
 	}
 </style>
 <section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">

--- a/thanks.html
+++ b/thanks.html
@@ -126,7 +126,9 @@
 {% endifequal %}
 
 </form>
-
+{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
+SHOW UPSELL
+{% endif %}
 		</div>
 	</div>
 		{% if page.custom_fields.thanks_show_map %}

--- a/thanks.html
+++ b/thanks.html
@@ -54,6 +54,23 @@
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+	
+	@media only screen and (max-width: 900px) {
+		.upsell_wrap {
+			width: 100%;
+			flex-wrap: wrap;	
+		}
+		#suggestions {
+			width: 100%;
+			flex-wrap: wrap;	
+		}
+		#suggestions button {
+			width: 100%;
+		}
+		.upsell_other_amt {
+			width: 100%;
+		}
+	}
 </style>
 <section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 	<div class="section-inner">

--- a/thanks.html
+++ b/thanks.html
@@ -160,26 +160,11 @@
 
 					$('#other_symbol').html(currencySymbols[currency])
 					$('#other_amt').addClass(currency)
-					 
-					// used to test
-					// $('#test_no').val(total)
-					 
-					// $('#test_no').on('input', function(e){
-					// 	total = parseFloat($(this).val())
-					// 	$('#suggestions').empty()
-					//     setupButtons();
-					// });
-					 
-					 setupButtons();
+					 					 
+					setupButtons();
 				});
 			</script>
 
-			<!-- used to test -->
-			<!-- <div class="test_wrap" style="margin-bottom:35px;">
-				<label>Test donation amount</label>
-				<input type="number" id="test_no">
-			</div>
-			 -->
 			 <div class="upsell_wrap">
 					<div id="suggestions"></div>
 					<div class="upsell_other_amt">

--- a/thanks.html
+++ b/thanks.html
@@ -50,6 +50,14 @@
 					var currency = 'USD';
 					var total = '10';
 					var maxDonation = 500;
+					var currencySymbols = {
+						"AUD": "AUD",
+						"BRL": "R$",
+						"CAD": "CAD",
+						"EUR": "€",
+						"GBP": "£",
+						"USD": "$",
+					}
 					
 					{% if action.order.currency %}
 					currency = '{{action.order.currency}}';
@@ -94,6 +102,8 @@
 					$('body').on('click', '#other_amt_btn', function(e){
 						window.location.href = url + '&amount='+$('#other_amt').val()
 					});
+
+					$('#other_symbol').html(currencySymbols[currency])
 					 
 					// used to test
 					// $('#test_no').val(total)
@@ -117,6 +127,7 @@
 			 <div class="upsell_wrap">
 					<div id="suggestions"></div>
 					<div class="upsell_other_amt">
+						<label id="other_symbol">$</label>
 						<input type="number" id="other_amt">
 						<button id="other_amt_btn" class="button">Give Monthly</button>
 					</div>

--- a/thanks.html
+++ b/thanks.html
@@ -58,13 +58,13 @@
 		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' %}
 			<script>
 				$(function() {
-					var currency = 'USD';
+					var currency = 'CAD';
 					var total = '10';
 					var maxDonation = 500;
 					var currencySymbols = {
-						"AUD": "AUD",
+						"AUD": "$",
 						"BRL": "R$",
-						"CAD": "CAD",
+						"CAD": "$",
 						"EUR": "€",
 						"GBP": "£",
 						"USD": "$",

--- a/thanks.html
+++ b/thanks.html
@@ -71,6 +71,23 @@
 			width: 100%;
 		}
 	}
+	@media only screen and (max-width: 448px) {
+		.upsell_other_amt {
+			flex-wrap: wrap;
+		}
+		.upsell_other_amt label {
+			transform: none;
+  		top: 14px;
+		}
+		.upsell_other_amt input {
+			width: 100%;
+			border-radius: 1.4em 1.4em 0 0;
+		}
+		.upsell_other_amt button {
+			width: 100%;
+			border-radius: 0 0 1.4em 1.4em;
+		}
+	}
 </style>
 <section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 	<div class="section-inner">

--- a/wrapper.html
+++ b/wrapper.html
@@ -229,7 +229,7 @@ actionkit.forms.initForm('act');
 </script>
 
 {% endif %}
-<div class="clear" /></div>
+<div class="clear" ></div>
 
 {% comment %}
 -------------


### PR DESCRIPTION
- Allows you to set the custom page field "Donate - Payment types appear as buttons (for testing)" as Y which will then set a new class on the payment types to make them look more like buttons.
- Stops rounding of total on step 3 button.
- Updated to work in IE 11
- Added in CVV field
- Added the upsell feature on the thanks page (dynamically sets button amounts based on the amount donated)
- Added ability to set a currency based on URL param (helps with the upsell so we can track currencies from page to page)
- Added state validation (based on a suggestion from ActionKit support)
- Fix bug where some fields were cut off on certain browsers

You can see this PR here: https://act.350.org/donate/fa-test/
I've added the custom page field to this template set already: https://act.350.org/admin/cms/templateset/281/templates

This branch is based on the donation-sprint branch, which that template set is based on.
Let me know if you need to know anything else.