### PR TITLE
Fa oct sprint

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -87,7 +87,6 @@ iframe[width="1"][height="1"] {
 #site-footer {
   top: 0;
   position: relative;
-  margin-top: 25px;
 }
 
 #site-footer nav {

--- a/thanks.html
+++ b/thanks.html
@@ -139,8 +139,9 @@
 					}
 					
 					var makeButton = function(amount) {
-						$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'/mo</button>')	
+						$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'{% filter ak_text:"donate_monthly_upsell_button_suffix" %}/mo{% endfilter %}</button>')	
 					}
+					
 
 					var pageLanguage = "{{page.lang.iso_code}}";
 
@@ -207,7 +208,7 @@
 					<div class="upsell_other_amt">
 						<label id="other_symbol">$</label>
 						<input type="number" id="other_amt">
-						<button id="other_amt_btn" class="button">Give Monthly</button>
+						<button id="other_amt_btn" class="button">{% filter ak_text:"donate_monthly_upsell_other_button" %}Give Monthly{% endfilter %}</button>
 					</div>
 			 </div>
 

--- a/thanks.html
+++ b/thanks.html
@@ -12,6 +12,7 @@
 	#suggestions {
 		display: flex;
 	}
+	
 	#suggestions button {
 		margin: 10px;
 		padding: 0.6em 1.2em;

--- a/thanks.html
+++ b/thanks.html
@@ -12,11 +12,16 @@
 	#suggestions {
 		display: flex;
 	}
-	
+	#suggestions button,
+	.upsell_other_amt button {
+		font-size: 1.8rem;
+		font-family: GraphCondensedWeb, -apple-system, BlinkMacSystemFont, Arial, sans-serif;
+		background: #0f81e8;
+		text-shadow: none;
+	}
 	#suggestions button {
 		margin: 10px;
 		padding: 0.6em 1.2em;
-		font-size: 1.4rem;
 	}
 	.upsell_other_amt {
 		display: flex;

--- a/thanks.html
+++ b/thanks.html
@@ -107,6 +107,13 @@
 		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' and not action.orderrecurring %}
 			<script>
 				$(function() {
+					function urlParam(name){
+						var results = new RegExp('[\\?&]' + name + '=([^&#]*)').exec(window.location.href);
+						if (!results) { return 0; }
+						return results[1] || 0;
+					}
+					var utmSource = urlParam('utm_source');
+					var source = urlParam('source');
 					var currency = 'USD';
 					var total = '10';
 					var maxDonation = 500;
@@ -134,8 +141,32 @@
 					var makeButton = function(amount) {
 						$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'/mo</button>')	
 					}
+
+					var pageLanguage = "{{page.lang.iso_code}}";
+
+					/** 
+					Add monthly donate page urls to the object below, using the iso-2 as the index and the URL as the value.
+					If a specific url for the page language isn't included, will default to english URL.
+					**/
+					var multilingualMonthlyDonateUrls = {
+						en: 'https://act.350.org/donate/make_it_monthly',
+						fr: 'https://act.350.org/donate/make_it_monthly_fr',
+						de: 'https://act.350.org/donate/make_it_monthly_de'
+					};
+
+					var baseUrl;
+
+					if (typeof multilingualMonthlyDonateUrls[pageLanguage] !== 'undefined') {
+						baseUrl = multilingualMonthlyDonateUrls[pageLanguage];
+					} else {
+						baseUrl = multilingualMonthlyDonateUrls.en;
+					}
 					
-					var url = 'https://act.350.org/donate/fa-test_recurring/?source=build-donate-ty&utm_source=build-donate-ty&currency='+currency
+					var url = baseUrl + '?source=';
+					if (source) url+= source;
+					url += '&utm_source=';
+					if (utmSource) url+= utmSource;
+					url += '&currency=' + currency;
 					
 					var setupButtons = function() {
 						if (total) {


### PR DESCRIPTION
**1. Updated monthly donate upsell button styling on donate thank you page** 
https://gitlab.com/350/product-fa-sprints/-/issues/10
Just css edits in thanks.html, lines 15-25.

**2. Dynamic monthly donate upsell URL**
https://gitlab.com/350/product-fa-sprints/-/issues/9
JS edits in thanks.html, likes 110-170.
- We're now pulling source and subsource from the URL.
- We're also pulling in the page language from ActionKit, and using that to determine which monthly donate page to link to in the upsell (defaulting to the english page).
- Source and subsource params from the current page URL is being added to the monthly upsell URLs. We pass in an empty string if they're not in the current page URL.
- Tested by switching the page language in ActionKit and seeing that the donate URL updates as expected

**3. Site footer gap on donate pages**
https://gitlab.com/350/product-fa-sprints/-/issues/29
This just needed a css change in donate.html on line 90, removing the margin-top on #site-footer

**4. Adding language strings**
https://gitlab.com/350/product-fa-sprints/-/issues/28
JS edits to thanks.html. Replaced hardcoded English copy with language strings, on lines 142 and 211
