### PR TITLE
Fix to stop donation errors getting redirected from the error page

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -843,6 +843,7 @@ iframe[width="1"][height="1"] {
 {% block script_additions %}
 
 <script language="javascript">
+
 //<!--
     // TODO: Commented out code needs to go.
     let paypalFieldOptionSelectedStepThree = false;
@@ -967,6 +968,8 @@ iframe[width="1"][height="1"] {
 			});
 
 		});
+    // Fix to stop donation errors gettin redirected from the error page
+    actionkit.utils.appendHiddenInput('referer_from_url', '1');
 
 /* Currency symbols */
 


### PR DESCRIPTION
Fix to stop donation errors getting redirected from the error page