### PR TITLE
Fa jan sprint

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -720,8 +720,11 @@
 
                         <div
                           class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} payments-title-active card-title ">
-                          <svg width="150" height="40" class="payments-title-active">
+                          <svg width="150" height="40" class="payments-title-active cards-us">
                             <image href=https://dkaroyc5da26m.cloudfront.net/images/cards.svg width="150" height="40" />
+                          </svg>
+                          <svg width="75" height="40" class="payments-title-active cards-non-us" style="display:none;">
+                            <image href="https://dbqvwi2zcv14h.cloudfront.net/images/cards-visa-mc.svg" width="75" height="40" />
                           </svg>
                         </div>
 
@@ -1162,11 +1165,15 @@
         $(this).children('input').prop('disabled', false);
       });
       $('.ak-intl-billing-fields').hide();
+      $('.cards-non-us').hide();
+      $('.cards-us').show();
     } else {
       $('.ak-us-billing-fields').hide();
       $('.ak-intl-billing-fields').show().each(function () {
         $(this).children('input').prop('disabled', false);
       });
+      $('.cards-non-us').show();
+      $('.cards-us').hide();
     }
     sync_to_shipping();
   }

--- a/language_picker.html
+++ b/language_picker.html
@@ -4,11 +4,13 @@
 	<div class="section-inner">
 		<ul class="menu">
 	{% for translated_page in translations %}
-		{% ifequal translated_page.id page.id %}
-			<li class="language-nav-item-{{ translated_page.name }}"><a class="disabled lang" lang="{{ translated_page.lang.iso_code }}">{{ translated_page.lang.name|default:"English" }}</a></li>
-		{% else %}
-			<li class="language-nav-item-{{ translated_page.name }}"><a class="lang lang-{{ translated_page.lang.iso_code }}" lang="{{ translated_page.lang.iso_code }}" href="/act/{{ translated_page.name }}/">{{ translated_page.lang.name|default:"English" }}</a></li>
-		{% endifequal %}
+		{% if translated_page.custom_fields.hide_from_language_picker != "Y" %}
+			{% ifequal translated_page.id page.id %}
+				<li class="language-nav-item-{{ translated_page.name }}"><a class="disabled lang" lang="{{ translated_page.lang.iso_code }}">{{ translated_page.lang.name|default:"English" }}</a></li>
+			{% else %}
+				<li class="language-nav-item-{{ translated_page.name }}"><a class="lang lang-{{ translated_page.lang.iso_code }}" lang="{{ translated_page.lang.iso_code }}" href="/act/{{ translated_page.name }}/">{{ translated_page.lang.name|default:"English" }}</a></li>
+			{% endifequal %}
+		{% endif %}
 	{% endfor %}
 		</ul>
 	</div>

--- a/thanks.html
+++ b/thanks.html
@@ -104,7 +104,7 @@
 		<div id="thanks-message" class="bg-dkgray-trans text-large3 c10 ct10 cm10 box box-huge margin-bottom-large">
 		{% include_tmpl form.thank_you_text %}
 		
-		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' and not action.orderrecurring %}
+		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' and not action.orderrecurring and not user.orderrecurring_set.active %}
 			<script>
 				$(function() {
 					function urlParam(name){


### PR DESCRIPTION
### Hide the monthly upsell for users who have an existing recurring donation
https://gitlab.com/350/product-fa-sprints/-/issues/33
- I just added a single condition to the if statement on line 107 of thanks.html
- Test page with upsell being hidden for user with recurring donation set up https://act.350.org/thanks/test-donate-monthlyupsell-active/?action_id=22908669&akid=.2287049.OrdOyq&ar=1&rd=1&total=1.00


### Add a custom page field allowing a page to be hidden from the language menu
https://gitlab.com/350/product-fa-sprints/-/issues/34
- Added a custom field called hide_from_language_picker
- Added an if statement to language_picker.html on line 7 which excludes any page that have hide_from_language_picker set to a value of 'Y'
- Example pages here that have been hidden from the languge picker via a custom field:
  https://act.350.org/letter/rachel-test-EN/ https://act.350.org/admin/core/letterpage/12919/
  https://act.350.org/letter/rachel-test-EN2/ https://act.350.org/admin/core/letterpage/12920/#
 

### On donate page, only show Mastercard and Visa logos for non-US countries
https://gitlab.com/350/product-fa-sprints/-/issues/35
- On line 723 of donate.html I added a class to the US card logos so we can hide/show them
- Below the US cards SVG I added another SVG which only has the Mastercard and Visa logos (set to display none)
- Leveraged the existing country_change function to hide/show either the US or the non-US card logos, based on the country select value (line 1175)
- Example page showing the functionality https://act.350.org/donate/build_rachel_test_eoy/