### PR TITLE
Fix: undefined exchangeRateData

### DIFF
--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -177,7 +177,7 @@ jQuery(document).ready(function($){
 		let exchangeRateData = {};
 		let exchangeApiUrl = 'https://api.exchangeratesapi.io/latest?base=USD';
 		$.get(exchangeApiUrl, function (data, status) {
-			exchangeRateData = data.rates;
+			if (data.rates) exchangeRateData = data.rates;
 		});
 		// set up variables
 		var afteractionProgressMeter = $("#afteraction-progress-meter");

--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -177,7 +177,7 @@ jQuery(document).ready(function($){
 		let exchangeRateData = {};
 		let exchangeApiUrl = 'https://api.exchangeratesapi.io/latest?base=USD';
 		$.get(exchangeApiUrl, function (data, status) {
-			if (data.rates) exchangeRateData = data.rates;
+			if (data && data.rates) exchangeRateData = data.rates;
 		});
 		// set up variables
 		var afteractionProgressMeter = $("#afteraction-progress-meter");


### PR DESCRIPTION
Fixes issue suggested by @JamieDraperFA  in [this Slack thread ](https://350team.slack.com/archives/GT7UF4US1/p1621349681012600)to address `exchangeRateData` being undefined due to failing API, leading to a TypeError. 