### PR TITLE
Fa sprint aug thank you and event page changes

### DIFF
--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4683,10 +4683,11 @@ label.ak-survey-radio-choice {
   width: 1.5em;
 }
 
-#thanks.thanks-alt .wf-tficons-n7-active #thanks-message p:first-child::before {
+.wf-tficons-n7-active #thanks.thanks-alt #thanks-message p:first-child::before {
   content: '';
   height: 0;
   width: 0;
+  margin-right: 0;
 }
 
 #thanks.thanks-alt #thanks-message h1,

--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4662,24 +4662,6 @@ label.ak-survey-radio-choice {
   font-weight: bold;
 }
 
-.wf-tficons-n7-active #thanks-message p:first-child::before {
-  background-color: rgb(0, 205, 100);
-  border-radius: 40px;
-  color: #fff;
-  /* content:'\E942'; */
-  content: '→';
-  display: inline-block;
-  font-family: KlimaWeb, sans-serif;
-  font-size: 0.75em;
-  height: 1.5em;
-  line-height: 1.75;
-  margin-right: 0.5em;
-  text-align: center;
-  vertical-align: text-bottom;
-  width: 1.5em;
-}
-
-
 /* Mobile formatting */
 #action-header {
   margin-top: 2rem;
@@ -5103,7 +5085,6 @@ input:checked+.toggle-donation-type .toggle-option-2 {
 
   /* Thanks pages */
   .wf-tficons-n7-active #thanks-message p {
-    padding-left: 1.8em;
     position: relative;
   }
 

--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4667,10 +4667,6 @@ label.ak-survey-radio-choice {
   font-family: KlimaWeb, Klima, -apple-system-, BlinkMacSystemFont, Arial, sans-serif;
 }
 
-#thanks-message p:first-child {
-  font-weight: bold;
-}
-
 /* Mobile formatting */
 #action-header {
   margin-top: 2rem;

--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4658,6 +4658,15 @@ label.ak-survey-radio-choice {
 
 /* Thanks pages */
 
+#thanks-message h1,
+#thanks-message h2,
+#thanks-message h3,
+#thanks-message h4
+#thanks-message h5,
+#thanks-message h6 {
+  font-family: KlimaWeb, Klima, -apple-system-, BlinkMacSystemFont, Arial, sans-serif;
+}
+
 #thanks-message p:first-child {
   font-weight: bold;
 }

--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4658,12 +4658,43 @@ label.ak-survey-radio-choice {
 
 /* Thanks pages */
 
-#thanks-message h1,
-#thanks-message h2,
-#thanks-message h3,
-#thanks-message h4
-#thanks-message h5,
-#thanks-message h6 {
+#thanks-message p:first-child {
+  font-weight: bold;
+}
+
+#thanks.thanks-alt #thanks-message p:first-child {
+  font-weight: inherit;
+}
+
+.wf-tficons-n7-active #thanks-message p:first-child::before {
+  background-color: rgb(0, 205, 100);
+  border-radius: 40px;
+  color: #fff;
+  /* content:'\E942'; */
+  content: '→';
+  display: inline-block;
+  font-family: KlimaWeb, sans-serif;
+  font-size: 0.75em;
+  height: 1.5em;
+  line-height: 1.75;
+  margin-right: 0.5em;
+  text-align: center;
+  vertical-align: text-bottom;
+  width: 1.5em;
+}
+
+#thanks.thanks-alt .wf-tficons-n7-active #thanks-message p:first-child::before {
+  content: '';
+  height: 0;
+  width: 0;
+}
+
+#thanks.thanks-alt #thanks-message h1,
+#thanks.thanks-alt #thanks-message h2,
+#thanks.thanks-alt #thanks-message h3,
+#thanks.thanks-alt #thanks-message h4
+#thanks.thanks-alt #thanks-message h5,
+#thanks.thanks-alt #thanks-message h6 {
   font-family: KlimaWeb, Klima, -apple-system-, BlinkMacSystemFont, Arial, sans-serif;
 }
 

--- a/date_picker.html
+++ b/date_picker.html
@@ -29,7 +29,7 @@
   {% else %}
 	<div class="input-text input-time input-time-{{ date_field.name }}">
     <label for="id_{{ date_field.name }}_time">{% filter ak_text:"field_event_starts_at_time"|capfirst %}Start Time (When people should show up in your local time, e.g. 2:00, 7:30){% endfilter %}</label>
-    <input type="text" size=8 name="{{ date_field.name }}_time" id="id_{{ date_field.name }}_time" value="{{ date_field.default_time }}" class="time text timepicker" format="time" placeholder="00:00"/>
+    <input type="text" size=8 name="{{ date_field.name }}_time" id="id_{{ date_field.name }}_time" value="{{ date_field.default_time }}" class="time text timepicker" format="time" placeholder="{% filter ak_text:"event_start_time_input_placeholder"%}hh:mm{% endfilter %}"/>
 	</div>
    <div class="input-select input-ampm input-ampm-{{ date_field.name }}">
     <label for="id_{{ date_field.name }}_ampm">{% filter ak_text:"general_am_pm" %}AM/PM{% endfilter %}</label>

--- a/event_create_field_set.html
+++ b/event_create_field_set.html
@@ -53,3 +53,11 @@
       </fieldset>
     </div>
   </div>
+
+	{% if page.custom_fields.event_alternate_venue_label %}
+		<script>
+			$(function(){
+				$('label[for="id_event_venue"]').html('{{ page.custom_fields.event_alternate_venue_label }}');
+			});
+		</script>
+	{% endif %}

--- a/thanks.html
+++ b/thanks.html
@@ -353,6 +353,13 @@
 </div>
 {% endif %}
 
+{% if page.custom_fields.thanks_alternate_thank_you_page_styling == 'Y' %}
+<script>
+	$(function(){
+		$('#thanks').addClass('thanks-alt');
+	});
+</script>
+{% endif %}
 
 {% endautoescape %}
 

--- a/thanks.html
+++ b/thanks.html
@@ -101,7 +101,7 @@
 		<input type="hidden" name="page" value="{{ page.name }}" />
 		{% include "./progress_meter.html" %}
 		</form>
-		<div id="thanks-message" class="bg-dkgray-trans text-large3 c10 ct10 cm10 box box-huge margin-bottom-large">
+		<div id="thanks-message" class="bg-dkgray-trans c10 ct10 cm10 box box-huge margin-bottom-large">
 		{% include_tmpl form.thank_you_text %}
 		
 		{% if page.custom_fields.thank_you_page_show_upsell == 'Y' and not action.orderrecurring and not user.orderrecurring_set.active %}


### PR DESCRIPTION
## Thank you page styling changes
https://gitlab.com/350/product-fa-sprints/-/issues/56
- Removed the green arrow from paragraphs
- Removed indentation from paragraph
- Changed headers to be Klima bold
- Change paragraphs to be default body font size (16px), and set font weight to normal

As requested by Rachel I've hidden these changes behind a custom field which sets a class of 'thanks-alt', which in turn is used in the selectors for the new styling :)
Changes can be seen here:
https://act.350.org/thanks/fa-aug-test-petition/

## Event page updates
https://act.350.org/thanks/fa-aug-test-petition/
- Add a custom field which sets the label for the venue field
- Change the event time paceholder to 'hh:mm', and add a language string

Changes can be seen here:
https://act.350.org/event/rachel-test-2021/create/