### PR TITLE
fix for sms opt ins not saving for pages with phone added via editor

### DIFF
--- a/user_form_wrapper.html
+++ b/user_form_wrapper.html
@@ -171,7 +171,7 @@
       // add mobile field if not already added, or show if already added
       if (!jQuery('#id_mobile_phone_box').length) {
         jQuery('#unknown_user').append(jQuery('<div id="id_mobile_phone_box" class="input-text ak-input-type-user  ak-err-below"><label for="id_mobile_phone">Mobile phone</label><input type="text" name="mobile_phone" id="id_mobile_phone" class="ak-userfield-input"></div>'));
-        jQuery('#id_mobile_phone_box').on('keyup change', function(){
+        jQuery('#id_mobile_phone').on('keyup change', function(){
           ifUSMobileIsProvided(selectedCountry, includeMobSubscriberInFormSubmission, excludeMobSubscriberInFormSubmission);
         });
       } else {
@@ -236,8 +236,8 @@
     }
 
     function excludeMobSubscriberInFormSubmission() {
-      // remove the name attr so we don't send the opt in field (if for example the user opts in but provides no number)
-      jQuery('#id_user_mobile_subscriber_true').attr('name', '');
+      // set user_mobile_subscriber_true name to action_mobile_subscriber_true so we don't record it as a true opt in, but instead as an acton field so we still have a record that the user opted in
+      jQuery('#id_user_mobile_subscriber_true').attr('name', 'action_mobile_subscriber_true');
       jQuery('#mobile_subscriber_number').attr('name', '');
       jQuery('#mobile_subscriber_number').val('');
     }
@@ -265,6 +265,12 @@
     var selectedCountry = jQuery('#country').val();
     ifCountryIsUS(selectedCountry, showMobileFields, hideMobileFields);
     ifUSMobileIsProvided(selectedCountry, includeMobSubscriberInFormSubmission, excludeMobSubscriberInFormSubmission);
+
+    if (jQuery('#id_mobile_phone_box').length) {
+      jQuery('#id_mobile_phone').on('keyup change', function(){
+        ifUSMobileIsProvided(selectedCountry, includeMobSubscriberInFormSubmission, excludeMobSubscriberInFormSubmission);
+      });
+    }
 
     jQuery('#country').on('change', function(){
       selectedCountry = jQuery(this).val();


### PR DESCRIPTION
Reported issue where SMS opt ins weren't being recorded if the mobile phone field was already added to the signup form via the page admin in AK.

Test page with these changes in here:
https://act.350.org/sign/fa-optin-test/

And a report for checking the test submissions:
https://act.350.org/report/page_actions_actionfields_userfields_and_phones/?page_id=14193

**Expected behaviour**
US country + mobile phone provided + SMS opt in checked:
mobile_subscriber_number actionfield being saved
mobile_subscriber userfield being saved

US country + no mobile phone provided + SMS opt in checked:
mobile_subscriber_true actionfield being saved

US country + no mobile phone provided + SMS opt in not checked:
mobile_subscriber_true actionfield not being saved
mobile_subscriber userfield not being saved

Other general testing by changing the country from US and then back to US, and then still seeing the above behaviour showing up in the report