### PR TITLE
E-commerce events tracking enhancements

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -1069,19 +1069,19 @@
    var country = document.getElementById("country").value
     dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
     dataLayer.push({
-        'event': 'checkout',
+      'event': 'checkout',
       'ecommerce': {
-          'checkout': { // 'add' actionFieldObject measures.
-            'actionField': {
-            'step': step,
-            'option': country,
+        'checkout': { // 'add' actionFieldObject measures.
+          'actionField': {
+          'step': step,
+          'option': country,
           },
           'products': [{
             'name': 'donation',       // Name or ID is required.
             'id': 'id_donation',
             'variant': amount_type,
             'price': price,
-                'quantity': 1,
+            'quantity': 1,
             'dimension2': frequency,
             'donationFrequency': frequency
           }]

--- a/donate.html
+++ b/donate.html
@@ -1029,7 +1029,7 @@
       if (step_has_errors) {
         return false;
       } else {
-        checkout_step_track(2, "paypal");
+        checkout_step_track(2, "cc");
         return true;
       }
     }

--- a/donate.html
+++ b/donate.html
@@ -24,7 +24,7 @@
     {% else %}
     <form id="act" name="act"
       class="{% if page.payfment_processor_information.use_tr %}braintree_form{% endif %} {{ templateset.custom_fields.donation_steps }} "
-      method="POST" action="https://350.actionkit.com/act/" accept-charset="utf-8">
+      method="POST" action="/act/" accept-charset="utf-8">
       <a id="jump-to-form" href="#donate"
         class="tablet-hide desktop-hide mobile-hide bg-orange text-underline-none text-center arrow-down text-large2">{% if page.custom_fields.form_submit_button_text %}{{ page.custom_fields.form_submit_button_text }}{% else %}{% filter ak_text:"donate_submit_button" %}Donate{% endfilter %}{% endif %}</a>
       <input type="hidden" name="page" value="{{ page.name }}">
@@ -248,6 +248,23 @@
                               onkeypress="return (event.charCode == 8 || event.charCode == 0) ? null : event.charCode >= 48 && event.charCode <= 57"
                               id="ak-other-amount-field" class="text-font-display" name="amount_other" size="3">
                           </label>
+                          <script>
+                            // Measures product impressions
+                            dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+                            dataLayer.push({
+                              'event': 'impression',
+                              'ecommerce': {
+                              'impressions': [
+                               {
+                                 'name': 'donation',
+                                 'id': 'id_donation',
+                                 'list': 'ak_donation_page',
+                                 'variant': 'custom',
+                                 'price': 'custom',
+                               }]
+                              }
+                            });
+                            </script>              
                         </li>
                         {% else %}
                         <li class="ak-amount-container c3_3 ct3_3 cm3_3 no-margin-bottom">
@@ -259,6 +276,23 @@
                               class="ak-amount-radio-button hidden" name="amount"
                               {% if not args.amount_other and amount == default_amount %}checked{% endif %}>
                           </label>
+                          <script>
+                            // Measures product impressions
+                            dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+                            dataLayer.push({
+                              'event': 'impression',
+                              'ecommerce': {
+                              'impressions': [
+                               {
+                                 'name': 'donation',
+                                 'id': 'id_donation',
+                                 'list': 'ak_donation_page',
+                                 'variant': 'preset',
+                                 'price': '{{amount}}',
+                               }]
+                              }
+                            });
+                            </script>              
                         </li>
                         {% endif %}
                         {% endfor %}
@@ -558,6 +592,24 @@
     var arg_amount_selected = false;
     var arg_amount = {{ args.amount|default:"false" }};
 
+    // Records Product "Details View" based on product click from Homepage
+	  dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+	  dataLayer.push({
+      'ecommerce': {
+        'detail': {
+          'actionField': {
+            'list': '{{ args.source|default:"" }}',
+          },
+          'products': [{
+            'name': 'donation',
+            'id': 'id_donation',
+            'variant': {% if args.amount  %} 'preset' {% else %} 'custom' {% endif %},
+            'price': '{{args.amount|default:""}}',
+          }]
+        }
+      }
+    });
+
     $('.ak-amount-wrapper .input-radio-button').each(function () {
       var current_amount = parseInt($(this).text().replace(/\D/g, ''));
       if (arg_amount && (arg_amount == current_amount)) {
@@ -678,6 +730,50 @@
   });
 
   function change_step_one_label(current_step) {
+    if (current_step == "1") {
+		// Records Add to Cart
+      var amount_container = $('li.ak-amount-container label.ak-radio-checked');
+      var amount;
+      var price;
+      var frequency;
+      var currency = document.querySelector('li.ak-amount-container>label>span.ak-currency-sym').innerHTML;
+      var button_amount = amount_container.find('span.ak-amount-button-amount').text();
+      var custom_amount = document.querySelector('#ak-other-amount-field').value;
+      if (!custom_amount) {
+        amount = button_amount;
+        amount_type = 'preset';
+        price = button_amount;
+      } else {
+        amount = 'custom';
+        amount_type = 'custom';
+        price = custom_amount;
+      }
+      if ($('input[name="donation_type"][type="hidden"]').val() === 'recurring') {
+        frequency = 'recurring';
+      } else {
+        frequency = 'single';
+      }
+
+      dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+  		dataLayer.push({
+        'event': 'addToCart',
+        'ecommerce': {
+          'add': {
+            'products': [{
+              'name': 'donation',
+              'id': 'id_donation',
+              'variant': amount_type,
+              'price': price,
+              'quantity': 1,
+              'dimension2': frequency
+            }]
+          }
+        }
+      });
+    } else if (current_step == "2") { 
+      // Records Checkout Step 1
+      checkout_step_track(1);
+    }
     {% comment %} // change amount label if step 1 is complete
     if (current_step === "1") {
       var amount_container = $('li.ak-amount-container label.ak-radio-checked');
@@ -919,6 +1015,7 @@
     $('#ak-exp_date_year-required').remove();
 
     /* and keep submitting */
+    checkout_step_track(2, "paypal");
     return true;
     }
 
@@ -932,6 +1029,7 @@
       if (step_has_errors) {
         return false;
       } else {
+        checkout_step_track(2, "paypal");
         return true;
       }
     }
@@ -945,6 +1043,52 @@
     step_3_validation()];
     return !(results[0] || results[1] || results[2]);
   }
+
+	function checkout_step_track(step, payment) {
+      var amount_container = $('li.ak-amount-container label.ak-radio-checked');
+      var amount;
+      var price;
+      var frequency;
+      var currency = document.querySelector('li.ak-amount-container>label>span.ak-currency-sym').innerHTML;
+      var button_amount = amount_container.find('span.ak-amount-button-amount').text();
+      var custom_amount = document.querySelector('#ak-other-amount-field').value;
+      if (!custom_amount) {
+		  amount = button_amount;
+		  amount_type = 'preset';
+		  price = button_amount;
+	  } else {
+		  amount = 'custom';
+		  amount_type = 'custom';
+		  price = custom_amount;
+	  }
+      if ($('input[name="donation_type"][type="hidden"]').val() === 'recurring') {
+        frequency = 'recurring';
+      } else {
+        frequency = 'single';
+      }
+	  var country = document.getElementById("country").value
+		dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+		dataLayer.push({
+		    'event': 'checkout',
+			'ecommerce': {
+			    'checkout': {                                // 'add' actionFieldObject measures.
+			        'actionField': {
+						'step': step,
+						'option': country,
+					},
+					'products': [{
+						'name': 'donation',       // Name or ID is required.
+						'id': 'id_donation',
+						'variant': amount_type,
+						'price': price,
+				        'quantity': 1,
+						'dimension2': frequency,
+						'donationFrequency': frequency
+					}]
+				}
+			}
+		});
+	}
 
   // Tab Creation Code
   $(function () {

--- a/donate.html
+++ b/donate.html
@@ -226,7 +226,7 @@
                         }
 
                         if (urlParam('currency')) {
-                      		$('#ak-currency-switcher').val('Braintree Client-Side Encryption ' + urlParam('currency')).change();
+                          $('#ak-currency-switcher').val('Braintree Client-Side Encryption ' + urlParam('currency')).change();
                         }
                       });
                     </script>
@@ -593,8 +593,8 @@
     var arg_amount = {{ args.amount|default:"false" }};
 
     // Records Product "Details View" based on product click from Homepage
-	  dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-	  dataLayer.push({
+    dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+    dataLayer.push({
       'ecommerce': {
         'detail': {
           'actionField': {
@@ -731,7 +731,7 @@
 
   function change_step_one_label(current_step) {
     if (current_step == "1") {
-		// Records Add to Cart
+    // Records Add to Cart
       var amount_container = $('li.ak-amount-container label.ak-radio-checked');
       var amount;
       var price;
@@ -755,7 +755,7 @@
       }
 
       dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-  		dataLayer.push({
+      dataLayer.push({
         'event': 'addToCart',
         'ecommerce': {
           'add': {
@@ -1044,7 +1044,7 @@
     return !(results[0] || results[1] || results[2]);
   }
 
-	function checkout_step_track(step, payment) {
+  function checkout_step_track(step, payment) {
       var amount_container = $('li.ak-amount-container label.ak-radio-checked');
       var amount;
       var price;
@@ -1053,42 +1053,42 @@
       var button_amount = amount_container.find('span.ak-amount-button-amount').text();
       var custom_amount = document.querySelector('#ak-other-amount-field').value;
       if (!custom_amount) {
-		  amount = button_amount;
-		  amount_type = 'preset';
-		  price = button_amount;
-	  } else {
-		  amount = 'custom';
-		  amount_type = 'custom';
-		  price = custom_amount;
-	  }
+      amount = button_amount;
+      amount_type = 'preset';
+      price = button_amount;
+    } else {
+      amount = 'custom';
+      amount_type = 'custom';
+      price = custom_amount;
+    }
       if ($('input[name="donation_type"][type="hidden"]').val() === 'recurring') {
         frequency = 'recurring';
       } else {
         frequency = 'single';
       }
-	  var country = document.getElementById("country").value
-		dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-		dataLayer.push({
-		    'event': 'checkout',
-			'ecommerce': {
-			    'checkout': {                                // 'add' actionFieldObject measures.
-			        'actionField': {
-						'step': step,
-						'option': country,
-					},
-					'products': [{
-						'name': 'donation',       // Name or ID is required.
-						'id': 'id_donation',
-						'variant': amount_type,
-						'price': price,
-				        'quantity': 1,
-						'dimension2': frequency,
-						'donationFrequency': frequency
-					}]
-				}
-			}
-		});
-	}
+   var country = document.getElementById("country").value
+    dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+    dataLayer.push({
+        'event': 'checkout',
+      'ecommerce': {
+          'checkout': { // 'add' actionFieldObject measures.
+            'actionField': {
+            'step': step,
+            'option': country,
+          },
+          'products': [{
+            'name': 'donation',       // Name or ID is required.
+            'id': 'id_donation',
+            'variant': amount_type,
+            'price': price,
+                'quantity': 1,
+            'dimension2': frequency,
+            'donationFrequency': frequency
+          }]
+        }
+      }
+    });
+  }
 
   // Tab Creation Code
   $(function () {

--- a/donate.html
+++ b/donate.html
@@ -1045,14 +1045,14 @@
   }
 
   function checkout_step_track(step, payment) {
-      var amount_container = $('li.ak-amount-container label.ak-radio-checked');
-      var amount;
-      var price;
-      var frequency;
-      var currency = document.querySelector('li.ak-amount-container>label>span.ak-currency-sym').innerHTML;
-      var button_amount = amount_container.find('span.ak-amount-button-amount').text();
-      var custom_amount = document.querySelector('#ak-other-amount-field').value;
-      if (!custom_amount) {
+    var amount_container = $('li.ak-amount-container label.ak-radio-checked');
+    var amount;
+    var price;
+    var frequency;
+    var currency = document.querySelector('li.ak-amount-container>label>span.ak-currency-sym').innerHTML;
+    var button_amount = amount_container.find('span.ak-amount-button-amount').text();
+    var custom_amount = document.querySelector('#ak-other-amount-field').value;
+    if (!custom_amount) {
       amount = button_amount;
       amount_type = 'preset';
       price = button_amount;
@@ -1061,12 +1061,12 @@
       amount_type = 'custom';
       price = custom_amount;
     }
-      if ($('input[name="donation_type"][type="hidden"]').val() === 'recurring') {
-        frequency = 'recurring';
-      } else {
-        frequency = 'single';
-      }
-   var country = document.getElementById("country").value
+    if ($('input[name="donation_type"][type="hidden"]').val() === 'recurring') {
+      frequency = 'recurring';
+    } else {
+      frequency = 'single';
+    }
+    var country = document.getElementById("country").value;
     dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
     dataLayer.push({
       'event': 'checkout',
@@ -1077,7 +1077,7 @@
           'option': country,
           },
           'products': [{
-            'name': 'donation',       // Name or ID is required.
+            'name': 'donation',
             'id': 'id_donation',
             'variant': amount_type,
             'price': price,

--- a/thanks.html
+++ b/thanks.html
@@ -115,6 +115,62 @@
 
 
 	</style>
+<script>
+function insertUrlParam(key, value) {
+	if (history.pushState) {
+		let searchParams = new URLSearchParams(window.location.search);
+		searchParams.set(key, value);
+		let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + searchParams.toString();
+		window.history.pushState({path: newurl}, '', newurl);
+	}
+}
+
+const params = new Proxy(new URLSearchParams(window.location.search), {
+  get: (searchParams, prop) => searchParams.get(prop),
+});
+
+let recorded = params.success; 
+
+var usecase = '';
+{% if action.page.custom_fields.page_use_case %} usecase = '{{ action.page.custom_fields.page_use_case }}';{% endif %}
+	// Send transaction data
+	dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+	if (recorded != 1) {
+		dataLayer.push({
+		  'event': 'transaction',
+		  'eventLabel': '{{ action.page.canonical_path }}',
+		  'ecommerce': {
+			'currencyCode': '{{action.order.currency}}',
+			'purchase': {
+			  'actionField': {
+				'id': '{{action.id}}',                         // Transaction ID. Required for purchases and refunds.
+				'affiliation': usecase,
+				'revenue': '{{action.order.total}}',                     // Total transaction value (incl. tax and shipping)
+				'tax':'0',
+				'shipping': '0',
+				'coupon': '',
+			  },
+			  'products': [{                            // List of productFieldObjects.
+				'name': 'donation',     // Name or ID is required.
+				'id': 'id_donation',
+				'price': '{{action.order.total}}',
+				'brand': '350.org',
+				'category': 'Donation',
+				'variant': '',
+				{% if action.orderrecurring %}
+				'dimension2': 'recurring',
+				{% else %}
+				'dimension2': 'single',
+				{% endif %}
+				'quantity': 1,
+				'coupon': ''                            // Optional fields may be omitted or set to empty string.
+			   }]
+			}
+		  }
+		});
+		insertUrlParam('success', 1);
+	}
+	</script>
 	<section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 		<div class="section-inner">
 			<form class="ak-form dummy" name="act" method="POST" action="/act/" accept-charset="utf-8">
@@ -161,6 +217,23 @@
 
 						var makeButton = function(amount) {
 							$('#suggestions').append('<button class="upsell_btn button" data-amt="'+parseInt(amount)+'">'+getCurrency(amount)+'{% filter ak_text:"donate_monthly_upsell_button_suffix" %}/mo{% endfilter %}</button>')
+						// Measures product impressions
+						dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+						dataLayer.push({
+						  'event': 'impression',
+						  'ecommerce': {
+						    'currencyCode': currency,
+							'impressions': [
+							 {
+							   'name': 'donation',       // Name or ID is required.
+							   'id': 'id_donation',
+							   'list': 'ak_thanks_page',
+							   'variant': 'preset',
+							   'price': parseInt(amount),
+							   'dimension2': 'recurring',
+							 }]
+						  }
+						});
 						}
 
 
@@ -226,6 +299,29 @@
 				</script>
 
 				<div class="upsell_wrap">
+					<script>
+						var currency = '';
+						{% if action.order.currency %}
+						currency = '{{action.order.currency}}';
+						{% endif %}
+						// Measures product impressions
+						dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+						dataLayer.push({
+						  'event': 'impression',
+						  'ecommerce': {
+						    'currencyCode': currency,
+							'impressions': [
+							 {
+							   'name': 'donation',       // Name or ID is required.
+							   'id': 'id_donation',
+							   'list': 'ak_thanks_page',
+							   'variant': 'custom',
+							   'price': 'custom',
+							   'dimension2': 'recurring',
+							 }]
+						  }
+						});
+					</script>
 						<div id="suggestions"></div>
 						<div class="upsell_other_amt">
 							<label id="other_symbol">$</label>
@@ -400,4 +496,3 @@ actionkit.forms.initForm('act');
 
 </script>
 {% endblock %}
-


### PR DESCRIPTION
## Add E-commerce event triggers to AK Donate+Thanks flow for Impressions, Detail View, Add to Cart, Checkout1, Checkout2, and Purchase 
## Related updates:
- Adjust POST destination link to address CORS issue
- Add "first load" `success` flag to Thanks QS params, to prevent manual page refreshes from triggering duplicate purchase records 

## Special Notes - regarding tasks required outside of this PR
- Currently, Google Tag Manager is configured to process only events originating from donation pages previously used specifically for tests/validation. This includes the Get Involved and Join pages, which are using a special test templateset which already contains the same E-commerce event triggers reflected in this PR. Until GTM is configured to process events on all pages, events outside of those test pages will not be processed and relayed to Google Analytics.
- Currently, a test view [[WTR] Donations](https://analytics.google.com/analytics/web/#/report/conversions-ecommerce-shopping-behavior/a4147446w7993349p257453087/_.useg%3Dbuiltin1%2CuserPbMD9l5RSm2NwiSB3BqGiw%26_r.activeSegmentId%3DuserPbMD9l5RSm2NwiSB3BqGiw) in GA is being used to receive the data relayed by GTM. For the general reporting views in GA to receive the data and expose the E-commerce reports, some minor configuration on the desired view is necessary (toggling Enhanced Ecommerce on, adding checkout step labels, adding custom dimensions...)

**Note on documentation**: A documentation update which may be used as an overall technical reference on this effort is now in progress. Until that is ready, feel free to reach out directly with questions. Thanks!