### PR TITLE
E-commerce - add Donation page type restriction for transactions

### DIFF
--- a/thanks.html
+++ b/thanks.html
@@ -115,61 +115,62 @@
 
 
 	</style>
-<script>
-function insertUrlParam(key, value) {
-	if (history.pushState) {
-		let searchParams = new URLSearchParams(window.location.search);
-		searchParams.set(key, value);
-		let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + searchParams.toString();
-		window.history.pushState({path: newurl}, '', newurl);
+	<script>
+	function insertUrlParam(key, value) {
+		if (history.pushState) {
+			let searchParams = new URLSearchParams(window.location.search);
+			searchParams.set(key, value);
+			let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + searchParams.toString();
+			window.history.pushState({path: newurl}, '', newurl);
+		}
 	}
-}
-
-const params = new Proxy(new URLSearchParams(window.location.search), {
-  get: (searchParams, prop) => searchParams.get(prop),
-});
-
-let recorded = params.success; 
-
-var usecase = '';
-{% if action.page.custom_fields.page_use_case %} usecase = '{{ action.page.custom_fields.page_use_case }}';{% endif %}
-	// Send transaction data
-	dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
-	if (recorded != 1) {
-		dataLayer.push({
-		  'event': 'transaction',
-		  'eventLabel': '{{ action.page.canonical_path }}',
-		  'ecommerce': {
-			'currencyCode': '{{action.order.currency}}',
-			'purchase': {
-			  'actionField': {
-				'id': '{{action.id}}',                         // Transaction ID. Required for purchases and refunds.
-				'affiliation': usecase,
-				'revenue': '{{action.order.total}}',                     // Total transaction value (incl. tax and shipping)
-				'tax':'0',
-				'shipping': '0',
-				'coupon': '',
-			  },
-			  'products': [{                            // List of productFieldObjects.
-				'name': 'donation',     // Name or ID is required.
-				'id': 'id_donation',
-				'price': '{{action.order.total}}',
-				'brand': '350.org',
-				'category': 'Donation',
-				'variant': '',
-				{% if action.orderrecurring %}
-				'dimension2': 'recurring',
-				{% else %}
-				'dimension2': 'single',
-				{% endif %}
-				'quantity': 1,
-				'coupon': ''                            // Optional fields may be omitted or set to empty string.
-			   }]
-			}
-		  }
+	{% if action.page.type == "Donation" %}
+		const params = new Proxy(new URLSearchParams(window.location.search), {
+		get: (searchParams, prop) => searchParams.get(prop),
 		});
-		insertUrlParam('success', 1);
-	}
+
+		let recorded = params.success; 
+
+		var usecase = '';
+		{% if action.page.custom_fields.page_use_case %} usecase = '{{ action.page.custom_fields.page_use_case }}';{% endif %}
+		// Send transaction data
+		dataLayer.push({ ecommerce: null });  // Clear the previous ecommerce object.
+		if (recorded != 1) {
+			dataLayer.push({
+			'event': 'transaction',
+			'eventLabel': '{{ action.page.canonical_path }}',
+			'ecommerce': {
+				'currencyCode': '{{action.order.currency}}',
+				'purchase': {
+				'actionField': {
+					'id': '{{action.id}}',                         // Transaction ID. Required for purchases and refunds.
+					'affiliation': usecase,
+					'revenue': '{{action.order.total}}',                     // Total transaction value (incl. tax and shipping)
+					'tax':'0',
+					'shipping': '0',
+					'coupon': '',
+				},
+				'products': [{                            // List of productFieldObjects.
+					'name': 'donation',     // Name or ID is required.
+					'id': 'id_donation',
+					'price': '{{action.order.total}}',
+					'brand': '350.org',
+					'category': 'Donation',
+					'variant': '',
+					{% if action.orderrecurring %}
+					'dimension2': 'recurring',
+					{% else %}
+					'dimension2': 'single',
+					{% endif %}
+					'quantity': 1,
+					'coupon': ''                            // Optional fields may be omitted or set to empty string.
+				}]
+				}
+			}
+			});
+			insertUrlParam('success', 1);
+		}
+	{% endif %}																									
 	</script>
 	<section id="thanks" class="section width-medium padding-medium bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 		<div class="section-inner">


### PR DESCRIPTION
## Brief
- Ecommerce "transactions" are being triggered upon action conversions other than "Donation" completions, such as "Signups." In the future it may be desired to augment the event info to track other types of conversions, but currently the event should only be recorded specifically on Donation conversions.

## Implements the following proposal:
1. https://github.com/350org/ak_intl_v3/issues/403#issuecomment-1293506362

Utilizes built in [AK variable](https://docs.actionkit.com/docs/manual/api/pages.html) for this conditional
@juliao762 @sukhada @cjmabry for viz

## QA Example
1. Go to [GTM](https://tagmanager.google.com/#/container/accounts/4702514756/containers/13424695/workspaces/133)
2. Preview the Signup test page - https://act.350.org/signup/eacop-week_ec - that is utilizing the [test templateset](https://act.350.org/admin/cms/templateset/474/templates) with this adjustment
3. Upon signup completion, "GA - Event - Transaction" should **not** be fired on the Thanks page visit
4. Preview the Donation test page - https://act.350.org/donate/web_join_redirect_ec - that is utilizing the [test templateset](https://act.350.org/admin/cms/templateset/474/templates) with this adjustment
5. Upon signup completion, "GA - Event - Transaction" **should** be fired on the Thanks page visit


