### PR TITLE
Fix ZAR symbol not showing up properly

### DIFF
--- a/assets/donate.js
+++ b/assets/donate.js
@@ -85,7 +85,8 @@ function clear_radio_buttons() {
     "GBP": "£",
     "USD": "$",
     "NZD": "NZ$",
-    "JPY": "¥"
+    "JPY": "¥",
+    "ZAR": "R"
   }
 
     // Sherezz and Kimani Did this. Blame them


### PR DESCRIPTION
The ZAR symbol needs to be added to the AK currency symbol utils so that it is rendered on donate pages next to each option if ZAR is selected via the currency switcher.