### PR TITLE
Add custom page field to set event contact email on event creation confirmation popup

### DIFF
--- a/event_created.html
+++ b/event_created.html
@@ -11,7 +11,7 @@
 <div class="section width-narrow padding-large bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 	<div class="section-inner bg-white padding-medium">
 		<h1>{% filter ak_text:"event_created_headline" %}You're almost done!{% endfilter %}</h1>
-		<p class="text-large2">{% filter ak_text:"event_created_text_pt1" %}Check your e-mail{% endfilter %} {% if args.email %} ( {{args.email}} ) {% endif %}{% filter ak_text:"event_created_text_pt2" %}and click the link inside it to confirm your event. If you don't see the email, check your spam folder — or email {{ page.custom_fields.event_contact_email_on_confirmation }}.{% endfilter %}</p>
+		<p class="text-large2">{% filter ak_text:"event_created_text_pt1" %}Check your e-mail{% endfilter %} {% if args.email %} ( {{args.email}} ) {% endif %}{% filter ak_text:"event_created_text_pt2" %}and click the link inside it to confirm your event. If you don't see the email, check your spam folder — or email {% if page.custom_fields.event_contact_email_on_confirmation %}{{ page.custom_fields.event_contact_email_on_confirmation }}{% else %}events@350.org.{% endif %}{% endfilter %}</p>
 	</div>
 </div>
 

--- a/event_created.html
+++ b/event_created.html
@@ -11,7 +11,7 @@
 <div class="section width-narrow padding-large bg-{% if page.custom_fields.page_background_color %}{{ page.custom_fields.page_background_color }}{% else %}white{% endif %}{% if page.custom_fields.page_background_image %}-fade{% endif %}">
 	<div class="section-inner bg-white padding-medium">
 		<h1>{% filter ak_text:"event_created_headline" %}You're almost done!{% endfilter %}</h1>
-		<p class="text-large2">{% filter ak_text:"event_created_text_pt1" %}Check your e-mail{% endfilter %} {% if args.email %} ( {{args.email}} ) {% endif %}{% filter ak_text:"event_created_text_pt2" %}and click the link inside it to confirm your event. If you don't see the email, check your spam folder — or email events@350.org.{% endfilter %}</p>
+		<p class="text-large2">{% filter ak_text:"event_created_text_pt1" %}Check your e-mail{% endfilter %} {% if args.email %} ( {{args.email}} ) {% endif %}{% filter ak_text:"event_created_text_pt2" %}and click the link inside it to confirm your event. If you don't see the email, check your spam folder — or email {{ page.custom_fields.event_contact_email_on_confirmation }}.{% endfilter %}</p>
 	</div>
 </div>
 


### PR DESCRIPTION
https://github.com/350org/ak_intl_v3/issues/428

When this is merged to master, we will need to revert the `event_created_text_p2` language string in EN and FR to `events@350.org`.