### PR TITLE
Add visual separation on mobile for events

### DIFF
--- a/event_search.html
+++ b/event_search.html
@@ -51,6 +51,18 @@
   }
   #event-search-country-wrapper select{
   }
+
+  @media screen and (max-width:768px){
+    li.event:nth-child(odd) > a.event-link {
+      box-shadow: 0 0 0 10px rgba(0,0,0,0.05);
+      background: rgba(0,0,0,0.05);
+    }
+
+    a.area-link.event-link:hover {
+      background: inherit !important;
+      box-shadow: inherit !important;
+    }
+  }
   @media screen and (min-width:900px){
   
     #page-header{


### PR DESCRIPTION
https://github.com/350org/action-tools/issues/261

**Original page**: https://act.350.org/event/global-power-up/
**Page with updated changes**: https://act.350.org/event/global-power-up/?template_set=350.org%20-%20International%20v3%20(Develop)

QA steps after PR is merged:

1. On desktop, the page should remain unchanged.
2. On mobile, the updated page should have alternating backgrounds like so:
![mobile-ss](https://github.com/350org/ak_intl_v3/assets/1696078/f397c81e-3367-471a-8497-811659313327)
