### PR TITLE
Reduce padding on event_attendee page

### DIFF
--- a/event_attend.html
+++ b/event_attend.html
@@ -148,7 +148,7 @@
 
 <div id="event-attend-details" class="section width-normal padding-none">
 	<div class="section-inner bg-white text-color-override">
-		<div class="padding-medium margin-bottom-none">
+		<div class="padding-small margin-bottom-none">
 		{% if campaign.show_public_description %}
 			{% autoescape off %}
 			<div class="event-description" data-read-more-after="3">{{ event.public_description }}</div>
@@ -181,7 +181,7 @@
 
 {% if form.ground_rules|is_nonblank and not update %}
 <div id="event-attend-rules" class="section width-normal padding-none">
-	<div class="section-inner bg-ltgray padding-medium">
+	<div class="section-inner bg-ltgray padding-small">
 		<div id="id_ground_rules_text" class="nojs">
 			<h3 class="section-header text-center margin-bottom-medium">Rules:</h3>
 			<hr>


### PR DESCRIPTION
https://github.com/350org/action-tools/issues/289

QA steps once PR is merged:

- Go to https://act.350.org/event/global-power-up/25813/signup/?template_set=350.org%20-%20International%20v3%20(Develop) and note that the space between the description and the event fields has reduced as compared to this URL: https://act.350.org/event/global-power-up/25813/signup.