### PR TITLE
Move CI/CD Pipeline from Buddy.works to GitHub Actions

### DIFF
--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -1,0 +1,35 @@
+name: Deploy AK Develop
+on:
+  push:
+    branches:
+      - new-pipeline
+jobs:
+    upload-and-notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Post to a Slack channel
+              id: slack
+              uses: slackapi/slack-github-action@v1.25.0
+              with:
+                # Slack channel id, channel name, or user id to post message.
+                # See also: https://api.slack.com/methods/chat.postMessage#channels
+                channel-id: 'CHZ9289JR'
+                    # For posting a rich message using Block Kit
+                payload: |
+                    {
+                        "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url }}",
+                        "blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                            "type": "mrkdwn",
+                            "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                            }
+                        }
+                        ]
+                    }
+              env:
+                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -39,7 +39,7 @@ jobs:
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "*Commit* \n ['${{ steps.commit_message.outputs.first_line }}''](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "*Commit* \n ['${{ steps.commit_message.outputs.first_line }}'](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -38,24 +38,24 @@ jobs:
 
       # 5) Send Slack notification
       # We'll use slackapi/slack-github-action for convenience
-      - name: Notify Slack Channel with Blocks
+      - name: Send Slack notification
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}  # or use your channel ID directly (e.g., "CHZ9289JR")
           payload: >
             {
-              "text": "${{ github.actor }} just deployed a build!",
+              "text": "*${{ github.event.repository.name }}* has been deployed by ${{ github.actor }}! 🚀",
               "blocks": [
                 {
                   "type": "section",
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Successful execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"
+                      "text": "*Successful execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Execution #${{ github.run_id }} ${{ github.event.head_commit.message}}>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Pipeline:* AK Develop"
+                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}|AK Develop>"
                     },
                     {
                       "type": "mrkdwn",
@@ -63,7 +63,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Project:* ${{ github.event.repository.name }}"
+                      "text": "*Project:* <${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name}}>"
                     }
                   ]
                 }

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -1,48 +1,73 @@
-name: Deploy AK Develop
+name: "AK Develop"
+
 on:
   push:
     branches:
       - new-pipeline
+
 jobs:
-    upload-and-notify:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+  deploy:
+    runs-on: ubuntu-latest
 
-            - name: Get first line of commit message
-              id: commit_message
-              run: |
-                echo "COMMIT_MESSAGE_FIRST_LINE=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
-                echo "::set-output name=first_line::$(git log -1 --pretty=%B | head -n 1)"
+    steps:
+      # 1) Check out code so we can access the files in this repository
+      - name: Check out code
+        uses: actions/checkout@v4
 
-            - name: Post to a Slack channel
-              id: slack
-              uses: slackapi/slack-github-action@v1.25.0
-              with:
-                # Slack channel id, channel name, or user id to post message.
-                # See also: https://api.slack.com/methods/chat.postMessage#channels
-                channel-id: 'CHZ9289JR'
-                    # For posting a rich message using Block Kit
-                payload: |
+      # 2) Configure AWS Credentials
+      # The AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION must be set as GitHub Secrets in your repo
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }} # e.g. 'us-east-1'
+
+      # 3) Upload assets to S3
+      - name: Upload 'assets' to S3
+        run: |
+          # Sync local 'assets' directory to s3://s3.350.org/ak-dev
+          aws s3 sync assets s3://s3.350.org/ak-dev --acl private
+
+      # 4) Invalidate the CloudFront cache
+      - name: Invalidate CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1A2162YKWCD00 \
+            --paths "/*"
+
+      # 5) Send Slack notification
+      # We'll use slackapi/slack-github-action for convenience
+      - name: Notify Slack Channel with Blocks
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: >
+            {
+              "text": "${{ github.actor }} just deployed a build!",
+              "blocks": [
+                {
+                  "type": "section",
+                  "fields": [
                     {
-                        "text": "*${{ github.repository }}* has been deployed by ${{ github.event.commit.committer.name }}! :tada: :rocket: :tada: \n",
-                        "blocks": [
-                        {
-                            "type": "section",
-                            "text": {
-                            "type": "mrkdwn",
-                            "text": "*Deployment result* \n ${{ job.status }}"
-                            }
-                        },
-                        {
-                            "type": "section",
-                            "text": {
-                            "type": "mrkdwn",
-                            "text": "*Commit* \n ['${{ steps.commit_message.outputs.first_line }}'](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
-                            }
-                        }
-                        ]
+                      "type": "mrkdwn",
+                      "text": "*Successful execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run #${{ github.run_id }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Pipeline:* AK Develop"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:* ${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:* ${{ github.event.repository.name }}"
                     }
-              env:
-                SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -3,7 +3,7 @@ name: "AK Develop"
 on:
   push:
     branches:
-      - new-pipeline
+      - develop
 
 jobs:
   deploy:

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -33,7 +33,7 @@ jobs:
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "**Commit** \n [\`${{ github.event.commit.message.split('\n')[0] }}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "**Commit** \n [`${{ github.event.commit.message.split('\n')[0] }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -10,6 +10,12 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Get first line of commit message
+              id: commit_message
+              run: |
+                echo "COMMIT_MESSAGE_FIRST_LINE=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
+                echo "::set-output name=first_line::$(git log -1 --pretty=%B | head -n 1)"
+
             - name: Post to a Slack channel
               id: slack
               uses: slackapi/slack-github-action@v1.25.0
@@ -33,7 +39,7 @@ jobs:
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "**Commit** \n [`${{ github.event.commit.message.split('\n')[0] }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "**Commit** \n [${{ steps.commit_message.outputs.first_line }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -20,13 +20,20 @@ jobs:
                     # For posting a rich message using Block Kit
                 payload: |
                     {
-                        "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url }}",
+                        "text": "**${{ github.repository }}** has been deployed by ${{ github.event.commit.committer.name }}! :tada: :rocket: :tada: \n",
                         "blocks": [
                         {
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                            "text": "**Deployment result** \n ${{ job.status }}"
+                            }
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                            "type": "mrkdwn",
+                            "text": "**Commit** \n [\'${{ github.event.commit.message.split('\n')[0] }}\'](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -26,20 +26,20 @@ jobs:
                     # For posting a rich message using Block Kit
                 payload: |
                     {
-                        "text": "**${{ github.repository }}** has been deployed by ${{ github.event.commit.committer.name }}! :tada: :rocket: :tada: \n",
+                        "text": "*${{ github.repository }}* has been deployed by ${{ github.event.commit.committer.name }}! :tada: :rocket: :tada: \n",
                         "blocks": [
                         {
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "**Deployment result** \n ${{ job.status }}"
+                            "text": "*Deployment result* \n ${{ job.status }}"
                             }
                         },
                         {
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "**Commit** \n [${{ steps.commit_message.outputs.first_line }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "*Commit* \n [${{ steps.commit_message.outputs.first_line }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -39,7 +39,7 @@ jobs:
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "*Commit* \n [${{ steps.commit_message.outputs.first_line }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "*Commit* \n ['${{ steps.commit_message.outputs.first_line }}''](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -33,7 +33,7 @@ jobs:
                             "type": "section",
                             "text": {
                             "type": "mrkdwn",
-                            "text": "**Commit** \n [\'${{ github.event.commit.message.split('\n')[0] }}\'](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+                            "text": "**Commit** \n [\`${{ github.event.commit.message.split('\n')[0] }}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
                             }
                         }
                         ]

--- a/.github/workflows/ak_develop.yml
+++ b/.github/workflows/ak_develop.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}  # or use your channel ID directly (e.g., "CHZ9289JR")
-          payload: >
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
             {
               "text": "*${{ github.event.repository.name }}* has been deployed by ${{ github.actor }}! 🚀",
               "blocks": [
@@ -55,7 +55,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}|AK Develop>"
+                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}/actions|AK Develop>"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -30,13 +30,19 @@ jobs:
             --distribution-id E1A2162YKWCD00 \
             --paths "/*"
 
+  notify_success:
+    needs: deploy
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Send Slack notification on success
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           payload: |
             {
-              "text": "*${{ github.event.repository.name }}* has been deployed by ${{ github.actor }}! 🚀",
+              "text": "*${{ github.event.repository.name }}* has been deployed by *${{ github.actor }}*! 🚀",
               "attachments": [
                 {
                   "fallback": "Deployment successful",
@@ -69,9 +75,11 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  on_failure:
+  notify_failure:
+    needs: deploy
+    if: ${{ failure() }}
     runs-on: ubuntu-latest
-    if: failure()
+
     steps:
       - name: Send Slack notification on failure
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -20,7 +20,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Upload 'assets' to S3 with Public Access
+      - name: Upload 'assets/' to S3 with Public Access
         run: |
           aws s3 sync assets/ s3://s3.350.org/ak/ --acl public-read
 

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -3,7 +3,7 @@ name: "Deploy Master"
 on:
   push:
     branches:
-      - new-pipeline
+      - master
 
 jobs:
   deploy:

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -1,0 +1,108 @@
+name: "Deploy Master Assets"
+
+on:
+  push:
+    branches:
+      - new-pipeline
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload 'assets' to S3 with Public Access
+        run: |
+          aws s3 sync assets/ s3://s3.350.org/ak/ --acl public-read
+
+      - name: Invalidate CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1A2162YKWCD00 \
+            --paths "/*"
+
+      - name: Send Slack notification on success
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "*${{ github.event.repository.name }}* has been deployed by ${{ github.actor }}! 🚀",
+              "attachments": [
+                {
+                  "fallback": "Deployment successful",
+                  "color": "good",
+                  "fields": [
+                    {
+                      "title": "Commit",
+                      "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.event.head_commit.message }}>",
+                      "short": true
+                    },
+                    {
+                      "title": "Pipeline",
+                      "value": "<${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>",
+                      "short": true
+                    },
+                    {
+                      "title": "Branch",
+                      "value": "${{ github.ref_name }}",
+                      "short": true
+                    },
+                    {
+                      "title": "Project",
+                      "value": "<${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>",
+                      "short": true
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  on_failure:
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Send Slack notification on failure
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "[#${{ github.run_id }}] Deployment failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Execution #${{ github.run_id }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:* ${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:* <${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -1,4 +1,4 @@
-name: "Deploy Master Assets"
+name: "Deploy Master"
 
 on:
   push:
@@ -10,50 +10,107 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 1) Check out code
       - name: Check out code
         uses: actions/checkout@v3
 
+      # 2) Configure AWS Credentials
+      # Make sure AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION
+      # are set as GitHub secrets in your repository.
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }} # e.g. 'us-east-1'
 
-      - name: Upload 'assets/' to S3 with Public Access
+      # 3) Upload assets to S3 with public read
+      - name: Upload 'assets/' to S3
         run: |
+          # Sync local 'assets/' directory to s3://s3.350.org/ak/ with public-read ACL
           aws s3 sync assets/ s3://s3.350.org/ak/ --acl public-read
 
+      # 4) Invalidate the CloudFront cache
       - name: Invalidate CloudFront Cache
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E1A2162YKWCD00 \
             --paths "/*"
 
-  notify_success:
-    needs: deploy
-    if: ${{ needs.deploy.result == 'success' }}
-    runs-on: ubuntu-latest
-
-    steps:
+      # 5) Send Slack notification on SUCCESS
       - name: Send Slack notification on success
-        uses: 8398a7/action-slack@v3
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          status: success
-          fields: repo,commit,author,action
+          # Replace with your Slack channel ID, or set as a secret
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "*${{ github.event.repository.name }}* has been deployed by ${{ github.actor }}! 🚀",
+              "attachments": [
+                {
+                  "fallback": "Deploy pipeline execution succeeded",
+                  "color": "good",
+                  "fields": [
+                    {
+                      "title": "Commit",
+                      "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.event.head_commit.message }}>",
+                      "short": true
+                    },
+                    {
+                      "title": "Pipeline",
+                      "value": "<${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>",
+                      "short": true
+                    },
+                    {
+                      "title": "Branch",
+                      "value": "${{ github.ref_name }}",
+                      "short": true
+                    },
+                    {
+                      "title": "Project",
+                      "value": "<${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>",
+                      "short": true
+                    }
+                  ]
+                }
+              ]
+            }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  notify_failure:
-    needs: deploy
-    if: ${{ needs.deploy.result == 'failure' }}
-    runs-on: ubuntu-latest
-
-    steps:
+      # 6) Send Slack notification on FAILURE
       - name: Send Slack notification on failure
-        uses: 8398a7/action-slack@v3
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          status: failure
-          fields: repo,commit,author,action
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "text": "[#${{ github.run_id }}] Deploy Master Assets FAILED",
+              "blocks": [
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Execution #${{ github.run_id }} ${{ github.event.head_commit.message }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:* ${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project:* <${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ak_master.yml
+++ b/.github/workflows/ak_master.yml
@@ -32,85 +32,28 @@ jobs:
 
   notify_success:
     needs: deploy
-    if: ${{ success() }}
+    if: ${{ needs.deploy.result == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Send Slack notification on success
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: 8398a7/action-slack@v3
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "*${{ github.event.repository.name }}* has been deployed by *${{ github.actor }}*! 🚀",
-              "attachments": [
-                {
-                  "fallback": "Deployment successful",
-                  "color": "good",
-                  "fields": [
-                    {
-                      "title": "Commit",
-                      "value": "<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.event.head_commit.message }}>",
-                      "short": true
-                    },
-                    {
-                      "title": "Pipeline",
-                      "value": "<${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>",
-                      "short": true
-                    },
-                    {
-                      "title": "Branch",
-                      "value": "${{ github.ref_name }}",
-                      "short": true
-                    },
-                    {
-                      "title": "Project",
-                      "value": "<${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>",
-                      "short": true
-                    }
-                  ]
-                }
-              ]
-            }
+          status: success
+          fields: repo,commit,author,action
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   notify_failure:
     needs: deploy
-    if: ${{ failure() }}
+    if: ${{ needs.deploy.result == 'failure' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Send Slack notification on failure
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: 8398a7/action-slack@v3
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          payload: |
-            {
-              "text": "[#${{ github.run_id }}] Deployment failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Failed execution:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Execution #${{ github.run_id }}>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Pipeline:* <${{ github.server_url }}/${{ github.repository }}/actions|Deploy Master Assets>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Branch:* ${{ github.ref_name }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Project:* <${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository.name }}>"
-                    }
-                  ]
-                }
-              ]
-            }
+          status: failure
+          fields: repo,commit,author,action
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate deployments for the `develop` and `master` branches. The workflows include steps for checking out the code, configuring AWS credentials, uploading assets to S3, invalidating the CloudFront cache, and sending Slack notifications.

### New GitHub Actions Workflows:

* [`.github/workflows/ak_develop.yml`](diffhunk://#diff-6e23417b4e20ea1a8ead19981599ecd953a4043a3ca9dd36e384b0bee605b432R1-R73): Adds a workflow for the `develop` branch that includes steps for checking out the code, configuring AWS credentials, uploading assets to S3 with private access, invalidating the CloudFront cache, and sending a Slack notification upon deployment.

* [`.github/workflows/ak_master.yml`](diffhunk://#diff-c0b2eb90f9a5317bfd7e30d83d4d97cd283cdca4543c6fe9a896468e8b03f6bcR1-R116): Adds a workflow for the `master` branch that includes steps for checking out the code, configuring AWS credentials, uploading assets to S3 with public-read access, invalidating the CloudFront cache, and sending Slack notifications on both successful and failed deployments.