### PR TITLE
Fix text colors in AK forms on white backgrounds

### DIFF
--- a/assets/ak-v3.css
+++ b/assets/ak-v3.css
@@ -4157,7 +4157,7 @@ label.ak-survey-radio-choice {
 
 .form-style-labelabove .input-radio.ak-input-type-action>label:first-child,
 .form-style-labelabove .input-checkbox.ak-input-type-action>label:first-child {
-  color: white;
+  color: inherit;
   cursor: default;
   display: block;
   font-size: 0.85em;

--- a/signup.html
+++ b/signup.html
@@ -60,7 +60,7 @@
 {% else %}
 		<form id="action-form" class="c4 ct7_5 cm10 c-wide form-changeorg form-style-labelabove ak-form action_form text-black" name="act" method="POST" action="/act/" accept-charset="utf-8">
 	{% autoescape off %}
-			<div id="t" class="p text-large text-lineheight-small strong text-white">
+			<div id="t" class="p text-large text-lineheight-small strong">
 		{% if page.custom_fields.form_text_above_form %}
 				{{ page.custom_fields.form_text_above_form }}
 		{% else %}

--- a/wrapper.html
+++ b/wrapper.html
@@ -182,11 +182,7 @@
 	TODO: Testing master push
 	-->
 
-<!-- 
 	<link rel='stylesheet' id='baseline-css' href='https://dbqvwi2zcv14h.cloudfront.net/ak/ak-v3.css'
-		type='text/css' media='screen' /> -->
-		
-	<link rel='stylesheet' id='baseline-css' href='https://xs17wgd2wu.ufs.sh/f/nX6SBdwGAudfQweIJH0By5HReBxivIJoZ8TcNY0Sn4PKXMmd'
 		type='text/css' media='screen' />
 
 	<link rel='stylesheet' href='https://dbqvwi2zcv14h.cloudfront.net/ak/custom.css' type='text/css' media='screen' />

--- a/wrapper.html
+++ b/wrapper.html
@@ -182,9 +182,13 @@
 	TODO: Testing master push
 	-->
 
-
+<!-- 
 	<link rel='stylesheet' id='baseline-css' href='https://dbqvwi2zcv14h.cloudfront.net/ak/ak-v3.css'
+		type='text/css' media='screen' /> -->
+		
+	<link rel='stylesheet' id='baseline-css' href='https://xs17wgd2wu.ufs.sh/f/nX6SBdwGAudfQweIJH0By5HReBxivIJoZ8TcNY0Sn4PKXMmd'
 		type='text/css' media='screen' />
+
 	<link rel='stylesheet' href='https://dbqvwi2zcv14h.cloudfront.net/ak/custom.css' type='text/css' media='screen' />
 
 	{% if templateset.custom_fields.site_addl_css_url %}


### PR DESCRIPTION
**JIRA Ticket:** [CT-110](https://350-product.atlassian.net/browse/CT-110)

## Description

This PR fixes the bug where links and text above forms in ActionKit are not appearing dark on white backgrounds. Tracked down the extra hardcoded styles "text-white" in the ActionKit signup templateset CSS, and also updated default label style by replacing `color: white;` with `color: inherit;`.

### Notes:
- Should test on non-white backgrounds to ensure there’s no regression.
- Baseline theme updates might not be necessary if this fix is sufficient.







[CT-110]: https://350-product.atlassian.net/browse/CT-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ