### PR TITLE
Fix PayPal can be hidden via custom page field 

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -843,8 +843,7 @@
                       {% endautoescape %}
                     </div>
                     {% endif %}
-                    {{page.hide_paypal}} HEre??
-                    {% if show_paypal or page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower == 'y' or not page.custom_fields.hide_paypal %}
+                    {% if show_paypal or page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower == 'y'%}
                     <div class="ak-payment-options text-center ak-donate-area-step-3 paypal-fields">
                       <input type="hidden" name="paypal" value="0" id="ak-pay-by-paypal">
                       <p class="margin-bottom-small text-small">

--- a/donate.html
+++ b/donate.html
@@ -130,7 +130,7 @@
   }
 
 </style>
-{% if templateset.custom_fields.donate_hide_paypal === "Y" %}
+{% if templateset.custom_fields.donate_hide_paypal.strip|lower == 'y' %}
 <style>
   .paypal-title{ display: none;}
 </style>

--- a/donate.html
+++ b/donate.html
@@ -721,11 +721,11 @@
                     <!-- <h5 class="margin-bottom-normal">{% filter ak_text:"donate_payment_information" %}Payment Information{% endfilter %}</h5> -->
                     <div class="payments-container">
                       <div class="payments-titles">
-
+                        <!-- Render non Paypal payment icons -->
                         {% if not page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower != 'y'  %}
 
                         <div
-                          class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} payments-title-active card-title ">
+                          class="payments-title {% if page.custom_fields.donation_payment_type_appearance.strip|lower == 'y' %}payment-title-button{% endif %} payments-title-active card-title ">
                           <svg width="150" height="40" class="payments-title-active cards-us">
                             <image href=https://dkaroyc5da26m.cloudfront.net/images/cards.svg width="150" height="40" />
                           </svg>
@@ -733,16 +733,18 @@
                             <image href="https://dbqvwi2zcv14h.cloudfront.net/images/cards-visa-mc.svg" width="75" height="40" />
                           </svg>
                         </div>
-
+                        {% if templateset.custom_fields.donate_hide_paypal.strip|lower != 'y' %}
                         <div
-                          class="payments-title {% if page.custom_fields.donation_payment_type_appearance == 'Y' %}payment-title-button{% endif %} paypal-title">
+                          class="payments-title {% if page.custom_fields.donation_payment_type_appearance.strip|lower == 'y' %}payment-title-button{% endif %} paypal-title">
                           <svg width="75" height="40">
                             <image href=https://dkaroyc5da26m.cloudfront.net/images/paypal-logo.svg width="75"
                               height="40" />
                           </svg>
                         </div>
                         {% endif %}
-                        {% if page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower == 'y'  %}
+                        {% endif %}
+                        <!-- Render Paypal payment icon -->
+                        {% if page.custom_fields.donation_only_paypal or page.custom_fields.donation_only_paypal.strip|lower == 'y'  %} 
                         <div class="payments-title payments-title-active paypal-title paypal-only">
                           <svg width="75" height="40">
                             <image href=https://dkaroyc5da26m.cloudfront.net/images/paypal-logo.svg width="75"


### PR DESCRIPTION
### PR Description

- Implements the `donate_hide_paypal` custom field in the v3 templateset to prevent overrides.  
- Hides PayPal when `donate_hide_paypal: 'y'` is set in a templateset.  

Ref: [CT-9](https://350-product.atlassian.net/browse/CT-9)

[CT-9]: https://350-product.atlassian.net/browse/CT-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ