### PR TITLE
Remove social proof optin message from thanks page

### DIFF
--- a/thanks.html
+++ b/thanks.html
@@ -616,10 +616,6 @@
 						</label>
 						<button type="submit" class="display-none submit-optin"></button>
 					</form>
-				{% elif user.custom_fields.optin_donate_social_proof == "Y" %}
-					<p class="text-center">
-						In 2025, it is more important than ever that we all come together to fight back — as hard as we can — against the fossil fuel companies, billionaires and right-wing politicians that are wrecking our planet. So thank you for showing your support for the climate movement.
-					</p>
 				{% endif %}
 			</div>
 			<form name="taf" method="POST" action="/update_action/" accept-charset="utf-8">


### PR DESCRIPTION
Remove thank you message for the social proof optin that's rendered on thanks pages