### PR TITLE
Fix GA tag being embedded twice onto homepage

### DIFF
--- a/afteraction-share.html
+++ b/afteraction-share.html
@@ -2,6 +2,8 @@
 Custom template for same-page post-AJAX submit share ask.
 {% endcomment %}
 
+{% if page.custom_fields.after_action_next_step == "flow" %}
+
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-V7QV8EHFVY"></script>
 <script>
@@ -11,6 +13,7 @@ Custom template for same-page post-AJAX submit share ask.
 
   gtag('config', 'G-V7QV8EHFVY');
 </script>
+{% endif %}
 
 <!-- {{page}} -->
 {% load actionkit_tags %}


### PR DESCRIPTION
https://trello.com/c/Yb0ibR4X/81-ga-page-views-overcounting